### PR TITLE
fix: current temperature not updated

### DIFF
--- a/custom_components/csnet_home/climate.py
+++ b/custom_components/csnet_home/climate.py
@@ -60,11 +60,6 @@ class CSNetHomeClimate(ClimateEntity):
         )
 
     @property
-    def temperature(self):
-        """Return the current temperature."""
-        return self._sensor_data["current_temperature"]
-
-    @property
     def current_temperature(self):
         """Return the current temperature."""
         return self._sensor_data["current_temperature"]
@@ -140,3 +135,12 @@ class CSNetHomeClimate(ClimateEntity):
         if not coordinator:
             _LOGGER.error("No coordinator instance found!")
         await coordinator.async_request_refresh()
+        self._sensor_data = next(
+            (
+                x
+                for x in coordinator.get_sensors_data()
+                if x.get("room_name") == self._attr_name
+            ),
+            None,
+        )
+        self._common_data = coordinator.get_common_data()

--- a/custom_components/csnet_home/coordinator.py
+++ b/custom_components/csnet_home/coordinator.py
@@ -20,7 +20,7 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.entry_id = entry_id
         self.update_interval = timedelta(seconds=update_interval)
-        self.device_data = {"sensors": [], "common_data": {}}
+        self._device_data = {"sensors": [], "common_data": {}}
         super().__init__(
             hass,
             _LOGGER,
@@ -41,15 +41,15 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
             return
 
         device_data = await cloud_api.async_get_elements_data()
-        self.device_data = device_data
-        return self.device_data
+        self._device_data = device_data
+        return self._device_data
 
     def get_sensors_data(self):
         """Return the list of sensor data."""
 
-        return self.device_data["sensors"]
+        return self._device_data["sensors"]
 
     def get_common_data(self):
         """Return common data shared between all sensors."""
 
-        return self.device_data["common_data"]
+        return self._device_data["common_data"]

--- a/custom_components/csnet_home/sensor.py
+++ b/custom_components/csnet_home/sensor.py
@@ -43,6 +43,7 @@ class CSNetHomeSensor(CoordinatorEntity, Entity):
     def __init__(self, coordinator: CSNetHomeCoordinator, sensor_data, common_data):
         """Initialize the sensor."""
         super().__init__(coordinator)
+        self._coordinator = coordinator
         self._sensor_data = sensor_data
         self._common_data = common_data
         self._name = f"{sensor_data['device_name']} {sensor_data['room_name']}"
@@ -75,6 +76,17 @@ class CSNetHomeSensor(CoordinatorEntity, Entity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update sensor with latest data from coordinator."""
+        self._sensor_data = next(
+            (
+                x
+                for x in self._coordinator.get_sensors_data()
+                if x.get("room_name") in self._name
+            ),
+            None,
+        )
+        self._common_data = self._coordinator.get_common_data()
+        self._current_temperature = self._sensor_data["current_temperature"]
+        self._planned_temperature = self._sensor_data["setting_temperature"]
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Why?
As reported in the Issue #2, the `currentTemperature` information for the Climate entity, is never updated. The value is set when the integration is started up and never changed.

## What?
When Home Assistant trigger the components data update, this information is now set within the Climate entity.