### PR TITLE
Fix internal documentation links for MkDocs compatibility

### DIFF
--- a/docs/wiki/Advanced-Features.md
+++ b/docs/wiki/Advanced-Features.md
@@ -681,12 +681,12 @@ automation:
 ## Next Steps
 
 Explore related documentation:
-- **[Multi-Zone Configuration](Multi-Zone-Configuration)** - Managing multiple circuits
-- **[Sensors Reference](Sensors-Reference)** - Complete sensor list
-- **[Climate Control](Climate-Control)** - Climate entity control with automation examples
-- **[Troubleshooting](Troubleshooting)** - Issue resolution
+- **[Multi-Zone Configuration](Multi-Zone-Configuration.md)** - Managing multiple circuits
+- **[Sensors Reference](Sensors-Reference.md)** - Complete sensor list
+- **[Climate Control](Climate-Control.md)** - Climate entity control with automation examples
+- **[Troubleshooting](Troubleshooting.md)** - Issue resolution
 
 ---
 
-**[← Back to Sensors](Sensors-Reference)** | **[Next: Multi-Zone Config →](Multi-Zone-Configuration)**
+**[← Back to Sensors](Sensors-Reference.md)** | **[Next: Multi-Zone Config →](Multi-Zone-Configuration.md)**
 

--- a/docs/wiki/Climate-Control.md
+++ b/docs/wiki/Climate-Control.md
@@ -771,13 +771,13 @@ automation:
 ## Next Steps
 
 Learn more about related features:
-- **[Water Heater Control](Water-Heater-Control)** - Control your DHW system
-- **[Sensors Reference](Sensors-Reference)** - All available sensors
-- **[Advanced Features](Advanced-Features)** - Silent mode, fan control, OTC
-- **[Multi-Zone Configuration](Multi-Zone-Configuration)** - Managing multiple circuits
-- **[Troubleshooting](Troubleshooting)** - Common issues and solutions
+- **[Water Heater Control](Water-Heater-Control.md)** - Control your DHW system
+- **[Sensors Reference](Sensors-Reference.md)** - All available sensors
+- **[Advanced Features](Advanced-Features.md)** - Silent mode, fan control, OTC
+- **[Multi-Zone Configuration](Multi-Zone-Configuration.md)** - Managing multiple circuits
+- **[Troubleshooting](Troubleshooting.md)** - Common issues and solutions
 
 ---
 
-**[← Back to Configuration](Configuration-Guide)** | **[Next: Water Heater →](Water-Heater-Control)**
+**[← Back to Configuration](Configuration-Guide.md)** | **[Next: Water Heater →](Water-Heater-Control.md)**
 

--- a/docs/wiki/Configuration-Guide.md
+++ b/docs/wiki/Configuration-Guide.md
@@ -6,7 +6,7 @@ This guide will help you configure the Hitachi CSNet Home integration after inst
 
 Before configuring, ensure:
 
-✅ Integration is installed (see [Installation Guide](Installation-Guide))  
+✅ Integration is installed (see [Installation Guide](Installation-Guide.md))  
 ✅ Home Assistant has been restarted  
 ✅ You have your CSNet Manager credentials ready  
 ✅ Your Hitachi system is connected to CSNet Manager and working
@@ -444,23 +444,23 @@ After configuration, verify everything is working:
 ✅ Configuration complete!
 
 Now explore:
-- **[Climate Control Guide](Climate-Control)** - Learn to control your zones
-- **[Water Heater Control](Water-Heater-Control)** - Manage your DHW
-- **[Sensors Reference](Sensors-Reference)** - Understand all sensors
-- **[Advanced Features](Advanced-Features)** - Silent mode, fan control, OTC
-- **[Multi-Zone Configuration](Multi-Zone-Configuration)** - Managing multiple circuits
+- **[Climate Control Guide](Climate-Control.md)** - Learn to control your zones
+- **[Water Heater Control](Water-Heater-Control.md)** - Manage your DHW
+- **[Sensors Reference](Sensors-Reference.md)** - Understand all sensors
+- **[Advanced Features](Advanced-Features.md)** - Silent mode, fan control, OTC
+- **[Multi-Zone Configuration](Multi-Zone-Configuration.md)** - Managing multiple circuits
 
 ---
 
 ## Getting Help
 
 If you need assistance:
-- Check [Troubleshooting](Troubleshooting) for common issues
-- Review [FAQ](FAQ) for frequent questions
+- Check [Troubleshooting](Troubleshooting.md) for common issues
+- Review [FAQ](FAQ.md) for frequent questions
 - Ask in [GitHub Discussions](https://github.com/mmornati/home-assistant-csnet-home/discussions)
 - Report bugs in [GitHub Issues](https://github.com/mmornati/home-assistant-csnet-home/issues)
 
 ---
 
-**[← Back to Installation](Installation-Guide)** | **[Next: Climate Control →](Climate-Control)**
+**[← Back to Installation](Installation-Guide.md)** | **[Next: Climate Control →](Climate-Control.md)**
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -48,7 +48,7 @@ Three methods:
 2. **Manual from Release** - Download ZIP from GitHub
 3. **Manual from Source** - Clone repository
 
-See complete instructions: [Installation Guide](Installation-Guide)
+See complete instructions: [Installation Guide](Installation-Guide.md)
 
 ### Do I need HACS?
 
@@ -140,7 +140,7 @@ The integration must log in to CSNet Manager on your behalf to retrieve data and
 - OTC settings
 - And many more!
 
-See complete list: [Sensors Reference](Sensors-Reference)
+See complete list: [Sensors Reference](Sensors-Reference.md)
 
 ### Can I control multiple zones independently?
 
@@ -152,7 +152,7 @@ Yes, through Home Assistant. If you've connected Home Assistant to Alexa or Goog
 
 ### Can I create automations?
 
-Absolutely! All entities can be used in Home Assistant automations, scripts, and scenes. Check the automation examples in [Climate Control](Climate-Control) and [Water Heater Control](Water-Heater-Control) pages.
+Absolutely! All entities can be used in Home Assistant automations, scripts, and scenes. Check the automation examples in [Climate Control](Climate-Control.md) and [Water Heater Control](Water-Heater-Control.md) pages.
 
 ---
 
@@ -379,7 +379,7 @@ Check:
 4. Is device online? (Check `connectivity` sensor)
 5. Did you wait 1-2 minutes for sync?
 
-See [Troubleshooting](Troubleshooting) for detailed help.
+See [Troubleshooting](Troubleshooting.md) for detailed help.
 
 ### Why do I see "Unavailable"?
 
@@ -538,10 +538,10 @@ There's no fixed roadmap. Development is driven by:
 
 ## Quick Links
 
-- **[Home](Home)** - Documentation home
-- **[Installation Guide](Installation-Guide)** - How to install
-- **[Configuration Guide](Configuration-Guide)** - How to configure
-- **[Troubleshooting](Troubleshooting)** - Fix issues
+- **[Home](Home.md)** - Documentation home
+- **[Installation Guide](Installation-Guide.md)** - How to install
+- **[Configuration Guide](Configuration-Guide.md)** - How to configure
+- **[Troubleshooting](Troubleshooting.md)** - Fix issues
 - **[GitHub Repository](https://github.com/mmornati/home-assistant-csnet-home)** - Source code
 - **[GitHub Issues](https://github.com/mmornati/home-assistant-csnet-home/issues)** - Bug reports
 - **[GitHub Discussions](https://github.com/mmornati/home-assistant-csnet-home/discussions)** - Community support
@@ -553,11 +553,11 @@ There's no fixed roadmap. Development is driven by:
 If your question isn't answered here:
 
 1. **Search the documentation** - Use your browser's find function (Ctrl+F)
-2. **Check [Troubleshooting](Troubleshooting)** - Common issues covered there
+2. **Check [Troubleshooting](Troubleshooting.md)** - Common issues covered there
 3. **Search [GitHub Discussions](https://github.com/mmornati/home-assistant-csnet-home/discussions)** - May already be answered
 4. **Ask in Discussions** - Create a new discussion thread
 
 ---
 
-**[← Back to Home](Home)** | **[Back to Troubleshooting](Troubleshooting)**
+**[← Back to Home](Home.md)** | **[Back to Troubleshooting](Troubleshooting.md)**
 

--- a/docs/wiki/Installation-Guide.md
+++ b/docs/wiki/Installation-Guide.md
@@ -81,7 +81,7 @@ After installation completes:
 3. Confirm the restart
 4. Wait for Home Assistant to come back online (usually 1-2 minutes)
 
-✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide).
+✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide.md).
 
 ---
 
@@ -167,7 +167,7 @@ config/
 2. Click **Restart**
 3. Wait for restart to complete
 
-✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide).
+✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide.md).
 
 ---
 
@@ -207,7 +207,7 @@ cp -r /tmp/home-assistant-csnet-home/custom_components/csnet_home custom_compone
 2. Click **Restart**
 3. Wait for restart to complete
 
-✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide).
+✅ **Installation Complete!** Proceed to the [Configuration Guide](Configuration-Guide.md).
 
 ---
 
@@ -328,9 +328,9 @@ If you see the integration in search results, installation was successful! 🎉
 
 Now that installation is complete:
 
-1. **Configure the integration**: Follow the [Configuration Guide](Configuration-Guide)
-2. **Explore features**: Check out [Climate Control](Climate-Control), [Water Heater Control](Water-Heater-Control), and [Sensors Reference](Sensors-Reference)
-3. **Customize your setup**: Visit [Advanced Features](Advanced-Features)
+1. **Configure the integration**: Follow the [Configuration Guide](Configuration-Guide.md)
+2. **Explore features**: Check out [Climate Control](Climate-Control.md), [Water Heater Control](Water-Heater-Control.md), and [Sensors Reference](Sensors-Reference.md)
+3. **Customize your setup**: Visit [Advanced Features](Advanced-Features.md)
 
 ---
 
@@ -405,22 +405,22 @@ rm -rf custom_components/csnet_home/
 ✅ Installation complete!
 
 Now proceed to:
-- **[Configuration Guide](Configuration-Guide)** - Set up the integration
-- **[Climate Control](Climate-Control)** - Control your heating and cooling zones
-- **[Water Heater Control](Water-Heater-Control)** - Manage your DHW system
-- **[Advanced Features](Advanced-Features)** - Explore all available features
+- **[Configuration Guide](Configuration-Guide.md)** - Set up the integration
+- **[Climate Control](Climate-Control.md)** - Control your heating and cooling zones
+- **[Water Heater Control](Water-Heater-Control.md)** - Manage your DHW system
+- **[Advanced Features](Advanced-Features.md)** - Explore all available features
 
 ---
 
 ## Getting Help
 
 If you encounter issues:
-- Check [Troubleshooting](Troubleshooting) page
+- Check [Troubleshooting](Troubleshooting.md) page
 - Search [GitHub Issues](https://github.com/mmornati/home-assistant-csnet-home/issues)
 - Ask in [GitHub Discussions](https://github.com/mmornati/home-assistant-csnet-home/discussions)
-- Review [FAQ](FAQ) for common questions
+- Review [FAQ](FAQ.md) for common questions
 
 ---
 
-**[← Back to Home](Home)** | **[Next: Configuration →](Configuration-Guide)**
+**[← Back to Home](Home.md)** | **[Next: Configuration →](Configuration-Guide.md)**
 

--- a/docs/wiki/Multi-Zone-Configuration.md
+++ b/docs/wiki/Multi-Zone-Configuration.md
@@ -703,12 +703,12 @@ automation:
 ## Next Steps
 
 Explore related documentation:
-- **[Climate Control](Climate-Control)** - Detailed climate entity control
-- **[Advanced Features](Advanced-Features)** - Silent mode, fan control, OTC
-- **[Sensors Reference](Sensors-Reference)** - All available sensors
-- **[Water Heater Control](Water-Heater-Control)** - DHW management
+- **[Climate Control](Climate-Control.md)** - Detailed climate entity control
+- **[Advanced Features](Advanced-Features.md)** - Silent mode, fan control, OTC
+- **[Sensors Reference](Sensors-Reference.md)** - All available sensors
+- **[Water Heater Control](Water-Heater-Control.md)** - DHW management
 
 ---
 
-**[← Back to Advanced Features](Advanced-Features)** | **[Back to Home](Home)**
+**[← Back to Advanced Features](Advanced-Features.md)** | **[Back to Home](Home.md)**
 

--- a/docs/wiki/Sensors-Reference.md
+++ b/docs/wiki/Sensors-Reference.md
@@ -779,12 +779,12 @@ sensor:
 ## Next Steps
 
 Explore related documentation:
-- **[Advanced Features](Advanced-Features)** - Silent mode, fan control, OTC
-- **[Climate Control](Climate-Control)** - Using sensors in climate control
-- **[Water Heater Control](Water-Heater-Control)** - DHW management
-- **[Troubleshooting](Troubleshooting)** - Sensor issues and solutions
+- **[Advanced Features](Advanced-Features.md)** - Silent mode, fan control, OTC
+- **[Climate Control](Climate-Control.md)** - Using sensors in climate control
+- **[Water Heater Control](Water-Heater-Control.md)** - DHW management
+- **[Troubleshooting](Troubleshooting.md)** - Sensor issues and solutions
 
 ---
 
-**[← Back to Water Heater](Water-Heater-Control)** | **[Next: Advanced Features →](Advanced-Features)**
+**[← Back to Water Heater](Water-Heater-Control.md)** | **[Next: Advanced Features →](Advanced-Features.md)**
 

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -760,12 +760,12 @@ Found a bug? Know how to fix it?
 
 ## Next Steps
 
-- Return to [Home](Home) page
-- Check [FAQ](FAQ) for quick answers
-- Review [Configuration Guide](Configuration-Guide)
+- Return to [Home](Home.md) page
+- Check [FAQ](FAQ.md) for quick answers
+- Review [Configuration Guide](Configuration-Guide.md)
 - Visit [GitHub Issues](https://github.com/mmornati/home-assistant-csnet-home/issues)
 
 ---
 
-**[← Back to Home](Home)** | **[Next: FAQ →](FAQ)**
+**[← Back to Home](Home.md)** | **[Next: FAQ →](FAQ.md)**
 

--- a/docs/wiki/Water-Heater-Control.md
+++ b/docs/wiki/Water-Heater-Control.md
@@ -718,12 +718,12 @@ automation:
 ## Next Steps
 
 Explore related documentation:
-- **[Climate Control](Climate-Control)** - Control heating zones
-- **[Sensors Reference](Sensors-Reference)** - All available sensors
-- **[Advanced Features](Advanced-Features)** - Additional system features
-- **[Multi-Zone Configuration](Multi-Zone-Configuration)** - Managing multiple circuits
+- **[Climate Control](Climate-Control.md)** - Control heating zones
+- **[Sensors Reference](Sensors-Reference.md)** - All available sensors
+- **[Advanced Features](Advanced-Features.md)** - Additional system features
+- **[Multi-Zone Configuration](Multi-Zone-Configuration.md)** - Managing multiple circuits
 
 ---
 
-**[← Back to Climate Control](Climate-Control)** | **[Next: Sensors Reference →](Sensors-Reference)**
+**[← Back to Climate Control](Climate-Control.md)** | **[Next: Sensors Reference →](Sensors-Reference.md)**
 


### PR DESCRIPTION
## Description

This PR fixes the remaining 404 errors in the documentation by adding  file extensions to all internal wiki links.

## Problem

After PR #106 fixed references to non-existent pages, the links still resulted in 404 errors on the published MkDocs site. This is because MkDocs requires the  extension for proper relative link resolution.

### Why Links Were Still Broken

When navigating from a page like:
```
https://mmornati.github.io/home-assistant-csnet-home/wiki/Climate-Control/
```

And clicking a link like:
```markdown
[Water Heater Control](Water-Heater-Control)
```

MkDocs interprets it as a relative path from the current page, resulting in:
```
https://mmornati.github.io/home-assistant-csnet-home/wiki/Climate-Control/Water-Heater-Control
```

Which returns **404 Not Found**.

### The Solution

Adding the `.md` extension tells MkDocs to treat it as a markdown file reference:
```markdown
[Water Heater Control](Water-Heater-Control.md)
```

Which correctly resolves to:
```
https://mmornati.github.io/home-assistant-csnet-home/wiki/Water-Heater-Control/
```

## Changes Made

Added `.md` extension to all internal wiki page links in:

1. **Installation-Guide.md**
   - Configuration Guide references
   - Feature page links  
   - Troubleshooting and FAQ links
   - Navigation footer links

2. **Configuration-Guide.md**
   - Installation Guide reference
   - Feature guide links
   - Help section links
   - Navigation footer

3. **Climate-Control.md**
   - Next Steps section links
   - Navigation footer

4. **Water-Heater-Control.md**
   - Related documentation links
   - Navigation footer

5. **Sensors-Reference.md**
   - Related documentation links
   - Navigation footer

6. **Advanced-Features.md**
   - Next Steps section links
   - Navigation footer

7. **Multi-Zone-Configuration.md**
   - Related documentation links
   - Navigation footer

8. **FAQ.md**
   - Multiple internal references throughout
   - Quick Links section
   - Navigation footer

9. **Troubleshooting.md**
   - Next Steps section links
   - Navigation footer

## Testing

✅ All internal links now include the `.md` extension  
✅ Links work correctly in the MkDocs published site  
✅ No more 404 errors when navigating between documentation pages  
✅ Links still work on GitHub markdown preview

## Impact

- ✅ Complete fix for documentation navigation issues
- ✅ Users can now successfully navigate between all documentation pages
- ✅ Improved documentation usability and user experience
- ✅ No more frustrating 404 errors

## Related

- Follows up on #106 which fixed references to non-existent pages
- Completes the documentation link fixes by ensuring MkDocs compatibility

## Verification

You can verify these links work by:
1. Downloading the documentation preview artifact from this PR
2. Serving it locally with `mkdocs serve` or `python -m http.server`
3. Clicking through the various "Next Steps" and "Related Documentation" links
4. Confirming no 404 errors occur