### PR TITLE
Fix temperature limits and add configurable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,20 @@ This custom integration solves that problem by connecting directly to the CSNet 
 - **Climate entities per zone** with full Home Assistant integration:
   - HVAC modes: `off`, `heat`, `cool`
   - Presets: `comfort`, `eco` (mapped from `ecocomfort`)
-  - Target temperature control
+  - Target temperature control with dynamic limits based on device type
   - On/Off support
   - Action reporting: `heating`, `cooling`, `idle`
   - Extended attributes: `real_mode`, `operation_status`, `timer_running`, `alarm_code`, `c1_demand`, `c2_demand`, `doingBoost`
+  - **Temperature Limits** (automatically detected):
+    - Air circuits (standard heat pumps): 8-35°C
+    - Water circuits (Yutaki/Hydro systems): 20-80°C
+    - Optional manual override available in configuration
 
 ### Water Heater
 - **DHW (Domestic Hot Water)** entity with:
-  - Temperature control
+  - Temperature control (30-80°C)
   - Operation modes: `off`, `eco`, `performance`
+  - Optional maximum temperature override
 
 ### Sensors
 - Temperature sensors (current and target)

--- a/custom_components/csnet_home/config_flow.py
+++ b/custom_components/csnet_home/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 
-from .const import DOMAIN, CONF_LANGUAGE, DEFAULT_LANGUAGE
+from .const import DOMAIN, CONF_LANGUAGE, DEFAULT_LANGUAGE, CONF_MAX_TEMP_OVERRIDE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,7 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._username = None
         self._password = None
         self._scan_interval = DEFAULT_SCAN_INTERVAL
+        self._max_temp_override = None
 
     async def async_step_user(self, user_input=None):
         """Handle user input for login credentials."""
@@ -41,6 +42,7 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_PASSWORD: self._password,
                     CONF_SCAN_INTERVAL: self._scan_interval,
                     CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
+                    CONF_MAX_TEMP_OVERRIDE: user_input.get(CONF_MAX_TEMP_OVERRIDE),
                 },
             )
 
@@ -56,6 +58,12 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
                         ["en", "fr"]
                     ),
+                    vol.Optional(CONF_MAX_TEMP_OVERRIDE): vol.All(
+                        vol.Coerce(int), vol.Range(min=8, max=80)
+                    ),
                 }
             ),
+            description_placeholders={
+                "max_temp_override_desc": "Optional: Override maximum temperature limit (8-80°C). Leave empty to use device defaults (35°C for air circuits, 80°C for water circuits/heaters)."
+            },
         )

--- a/custom_components/csnet_home/const.py
+++ b/custom_components/csnet_home/const.py
@@ -8,6 +8,7 @@ INSTALLATION_DEVICES_PATH = "/data/installationdevices"
 INSTALLATION_ALARMS_PATH = "/data/installationalarms"
 HEAT_SETTINGS_PATH = "/data/indoor/heat_setting"
 CONF_ENABLE_DEVICE_LOGGING = "enable_device_logging"
+CONF_MAX_TEMP_OVERRIDE = "max_temp_override"
 COMMON_API_HEADERS = {
     "accept-language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
     "cache-control": "no-cache",
@@ -17,11 +18,16 @@ COMMON_API_HEADERS = {
 }
 DEFAULT_API_TIMEOUT = 10
 
-WATER_HEATER_MAX_TEMPERATURE = 55
+WATER_HEATER_MAX_TEMPERATURE = 80
 WATER_HEATER_MIN_TEMPERATURE = 30
 
-HEATING_MAX_TEMPERATURE = 55
+# Air circuit (RTU) temperature limits - for zones 1, 2 (C1_AIR, C2_AIR)
+HEATING_MAX_TEMPERATURE = 35  # RTU_MAX from JavaScript
 HEATING_MIN_TEMPERATURE = 8
+
+# Water circuit temperature limits - for zones 5, 6 (C1_WATER, C2_WATER)
+WATER_CIRCUIT_MAX_HEAT = 80  # C1_MAX_HEAT / C2_MAX_HEAT from JavaScript
+WATER_CIRCUIT_MIN_HEAT = 20
 
 # Fan Speed Control (for fan coil systems)
 FAN_SPEED_OFF = "0"

--- a/docs/wiki/Configuration-Guide.md
+++ b/docs/wiki/Configuration-Guide.md
@@ -35,6 +35,7 @@ You'll see a configuration dialog with the following fields:
 | **Password** | Your CSNet Manager password | `••••••••` |
 | **Scan Interval** | Update frequency in seconds (default: 60) | `60` |
 | **Language** | Alarm message language | `en` or `fr` |
+| **Max Temp Override** | Optional maximum temperature override (8-80°C) | `45` (leave empty for auto) |
 
 **[PLACEHOLDER: Screenshot of configuration dialog]**
 
@@ -59,6 +60,20 @@ You'll see a configuration dialog with the following fields:
 - **Options**: `en` (English) or `fr` (French)
 - **Default**: `en`
 - Can be changed later by reconfiguring
+
+**Max Temp Override** (Optional, Advanced)
+- Allows you to override the maximum temperature limit for all climate entities
+- **Range**: 8-80°C
+- **Default behavior** (when empty):
+  - Air circuits (standard heat pumps): 35°C maximum
+  - Water circuits (Yutaki/Hydro systems): 80°C maximum  
+  - Water heaters (DHW): 80°C maximum
+- **Use cases**:
+  - Special hardware configurations
+  - Testing purposes
+  - Custom installations requiring non-standard limits
+- ⚠️ **Warning**: Setting this above manufacturer specifications may prevent your system from reaching the target temperature
+- 💡 **Recommendation**: Leave empty unless you have a specific reason to override
 
 ### Step 3: Submit Configuration
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1420,6 +1420,46 @@ def test_get_temperature_limits_zone3_dhw(hass):
     assert max_temp == 60
 
 
+def test_get_temperature_limits_zone6_heating(hass):
+    """Test temperature limits extraction for zone 6 (C2_WATER water circuit) in heating mode."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "heatMinC2": 25,
+            "heatMaxC2": 60,
+            "coolMinC2": 15,
+            "coolMaxC2": 22,
+        }
+    }
+
+    # Zone 6, heating mode (mode=1)
+    min_temp, max_temp = api.get_temperature_limits(6, 1, installation_devices_data)
+
+    assert min_temp == 25
+    assert max_temp == 60
+
+
+def test_get_temperature_limits_zone6_cooling(hass):
+    """Test temperature limits extraction for zone 6 (C2_WATER water circuit) in cooling mode."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "heatMinC2": 25,
+            "heatMaxC2": 60,
+            "coolMinC2": 15,
+            "coolMaxC2": 22,
+        }
+    }
+
+    # Zone 6, cooling mode (mode=0)
+    min_temp, max_temp = api.get_temperature_limits(6, 0, installation_devices_data)
+
+    assert min_temp == 15
+    assert max_temp == 22
+
+
 def test_get_temperature_limits_no_data(hass):
     """Test temperature limits extraction when no installation devices data is available."""
     api = CSNetHomeAPI(hass, "user", "pass")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -13,6 +13,7 @@ from custom_components.csnet_home.const import (
     DOMAIN,
     HEATING_MIN_TEMPERATURE,
     HEATING_MAX_TEMPERATURE,
+    CONF_MAX_TEMP_OVERRIDE,
     OPST_OFF,
     OPST_COOL_D_OFF,
     OPST_COOL_T_OFF,
@@ -74,7 +75,7 @@ def build_entity(
         "fan2_speed": fan2_speed,
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Minimal hass structure for the entity
     if not hasattr(hass, "data"):
@@ -458,7 +459,7 @@ def test_dynamic_temperature_limits_zone2(hass):
         "zone_id": 2,  # Zone 2
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Setup hass data
     if not hasattr(hass, "data"):
@@ -498,6 +499,139 @@ def test_dynamic_temperature_limits_zone2(hass):
     # Test min and max temperature for zone 2
     assert entity.min_temp == 12
     assert entity.max_temp == 28
+
+
+def test_max_temp_override_in_config(hass):
+    """Test that max_temp_override from config takes precedence."""
+    sensor_data = {
+        "device_name": "Hitachi PAC",
+        "device_id": 1234,
+        "room_name": "Living Room",
+        "parent_id": 1706,
+        "room_id": 395,
+        "operation_status": 5,
+        "mode": 1,  # Heat mode
+        "real_mode": 1,
+        "on_off": 1,
+        "timer_running": False,
+        "alarm_code": 0,
+        "c1_demand": True,
+        "c2_demand": False,
+        "ecocomfort": 1,
+        "silent_mode": 0,
+        "current_temperature": 20.0,
+        "setting_temperature": 22.0,
+        "zone_id": 1,  # Zone 1
+    }
+    common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
+
+    # Create entry with max_temp_override set to 45
+    entry = SimpleNamespace(entry_id="test-entry", data={CONF_MAX_TEMP_OVERRIDE: 45})
+
+    # Setup hass data
+    if not hasattr(hass, "data"):
+        hass.data = {}
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if entry.entry_id not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][entry.entry_id] = {}
+
+    # Mock the API to return normal temperature limits (should be overridden)
+    mock_api = SimpleNamespace(
+        get_temperature_limits=lambda zone_id, mode, data: (11, 30),
+        async_set_hvac_mode=AsyncMock(return_value=True),
+        async_set_temperature=AsyncMock(return_value=True),
+        set_preset_modes=AsyncMock(return_value=True),
+        async_set_silent_mode=AsyncMock(return_value=True),
+        is_fan_coil_compatible=lambda data: False,
+        get_fan_control_availability=lambda circuit, mode, data: False,
+    )
+    mock_coordinator = SimpleNamespace(
+        get_installation_devices_data=lambda: {
+            "heatingStatus": {
+                "heatAirMinC1": 11,
+                "heatAirMaxC1": 30,
+            }
+        },
+        get_sensors_data=lambda: [sensor_data],
+        get_common_data=lambda: {"device_status": {1234: common_data}},
+        async_request_refresh=AsyncMock(return_value=None),
+    )
+
+    hass.data[DOMAIN][entry.entry_id]["api"] = mock_api
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = mock_coordinator
+
+    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+
+    # Test that override value is used (45°C instead of API limit 30°C or default 35°C)
+    assert entity.min_temp == 11  # Min is not overridden
+    assert entity.max_temp == 45  # Max is overridden
+
+
+def test_max_temp_no_override(hass):
+    """Test that max_temp uses API/defaults when no override is configured."""
+    sensor_data = {
+        "device_name": "Hitachi PAC",
+        "device_id": 1234,
+        "room_name": "Living Room",
+        "parent_id": 1706,
+        "room_id": 395,
+        "operation_status": 5,
+        "mode": 1,
+        "real_mode": 1,
+        "on_off": 1,
+        "timer_running": False,
+        "alarm_code": 0,
+        "c1_demand": True,
+        "c2_demand": False,
+        "ecocomfort": 1,
+        "silent_mode": 0,
+        "current_temperature": 20.0,
+        "setting_temperature": 22.0,
+        "zone_id": 1,
+    }
+    common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
+
+    # Create entry WITHOUT max_temp_override
+    entry = SimpleNamespace(entry_id="test-entry", data={})  # No override
+
+    # Setup hass data
+    if not hasattr(hass, "data"):
+        hass.data = {}
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if entry.entry_id not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][entry.entry_id] = {}
+
+    # Mock the API to return temperature limits
+    mock_api = SimpleNamespace(
+        get_temperature_limits=lambda zone_id, mode, data: (11, 30),
+        async_set_hvac_mode=AsyncMock(return_value=True),
+        async_set_temperature=AsyncMock(return_value=True),
+        set_preset_modes=AsyncMock(return_value=True),
+        async_set_silent_mode=AsyncMock(return_value=True),
+        is_fan_coil_compatible=lambda data: False,
+        get_fan_control_availability=lambda circuit, mode, data: False,
+    )
+    mock_coordinator = SimpleNamespace(
+        get_installation_devices_data=lambda: {
+            "heatingStatus": {
+                "heatAirMinC1": 11,
+                "heatAirMaxC1": 30,
+            }
+        },
+        get_sensors_data=lambda: [sensor_data],
+        get_common_data=lambda: {"device_status": {1234: common_data}},
+        async_request_refresh=AsyncMock(return_value=None),
+    )
+
+    hass.data[DOMAIN][entry.entry_id]["api"] = mock_api
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = mock_coordinator
+
+    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+
+    # Test that API value is used (30°C from API)
+    assert entity.max_temp == 30
 
 
 # Fan Coil System Tests
@@ -817,7 +951,7 @@ def test_otc_attributes_zone1_heating_fix(hass):
         "fan2_speed": None,
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Setup installation devices data with OTC information
     installation_devices_data = {
@@ -890,7 +1024,7 @@ def test_otc_attributes_zone2_heating_gradient(hass):
         "fan2_speed": None,
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Setup installation devices data with OTC information for circuit 2
     installation_devices_data = {
@@ -963,7 +1097,7 @@ def test_otc_attributes_zone5_water_circuit(hass):
         "fan2_speed": None,
     }
     common_data = {"name": "Hitachi Yutaki", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Setup installation devices data with OTC information
     installation_devices_data = {
@@ -1036,7 +1170,7 @@ def test_otc_attributes_no_installation_data(hass):
         "fan2_speed": None,
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
@@ -1095,7 +1229,7 @@ def test_otc_attributes_zone3_dhw_no_otc(hass):
         "fan2_speed": None,
     }
     common_data = {"name": "Hitachi PAC", "firmware": "1.0.0"}
-    entry = SimpleNamespace(entry_id="test-entry")
+    entry = SimpleNamespace(entry_id="test-entry", data={})
 
     # Setup installation devices data with OTC information
     installation_devices_data = {


### PR DESCRIPTION
## Description

This PR fixes incorrect temperature limits (Issue #114) and adds a new configurable parameter to override maximum temperature when needed.

## Problem Fixed

Temperature limits did not match the original CSNet website implementation:
- **Air circuits** (zones 1, 2): Had max 55°C instead of 35°C
- **Water heater** (zone 3): Had max 55°C instead of 80°C  
- **Zone 6** (C2_WATER): Was not supported

## Solution

Analyzed the original JavaScript code from the CSNet website and corrected all temperature limits:

| Zone Type | Old Max | New Max | Standard |
|-----------|---------|---------|----------|
| Air circuits (1, 2) | 55°C | **35°C** | RTU_MAX |
| Water heater (3) | 55°C | **80°C** | DHW_MAX |
| Water circuits (5, 6) | N/A | **80°C** | C1/C2_MAX_HEAT |

## New Feature: Max Temperature Override

Added optional **`max_temp_override`** configuration parameter:
- **Range**: 8-80°C (validated)
- **Use cases**: Special hardware, testing, custom installations
- **Priority**: User override → API limits → Device defaults
- **Default**: Empty (automatic detection recommended)

Available in integration setup dialog for all users.

## Changes

### Core Files
- **const.py**: Added zone-specific temperature constants
- **api.py**: Added zone 6 support, improved documentation
- **climate.py**: Implemented priority-based max_temp logic
- **water_heater.py**: Same override logic for DHW
- **config_flow.py**: Added override field to setup form

### Tests
- Added 4 tests for zone 6 temperature limits
- Added 2 tests for override functionality  
- Fixed 4 existing tests for new entry structure
- ✅ All 18 temperature tests passing

### Documentation
- Updated Configuration Guide with override details
- Updated README with temperature limit information

## Testing

```bash
pytest tests/test_climate.py tests/test_api.py -k "temperature" -v
# Result: 18 passed
```

## Backward Compatibility

✅ Fully backward compatible
- Existing installations continue working with new correct limits
- No breaking changes to API or configuration

## Screenshots

Configuration dialog now includes optional override field:

| Field | Description |
|-------|-------------|
| Max Temp Override | Optional: Override max temperature (8-80°C) |

_(Leave empty for automatic detection based on device type)_

Closes #114