### PR TITLE
fix: align outdoor operation status mapping with CSNet constants

### DIFF
--- a/custom_components/csnet_home/sensor.py
+++ b/custom_components/csnet_home/sensor.py
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
     OTC_HEATING_TYPE_NAMES,
     OTC_COOLING_TYPE_NAMES,
+    OPERATION_STATUS_MAP,
 )
 from .coordinator import CSNetHomeCoordinator
 
@@ -1635,18 +1636,9 @@ class CSNetHomeCompressorSensor(CoordinatorEntity, Entity):
         # Outdoor unit information
         if self._key == "operation_status":
             value = heating_status.get("operationStatus")
-            # Decode operation status codes
-            operation_status_map = {
-                0: "Standby",
-                1: "Preheating",
-                2: "Heating",
-                3: "Cooling",
-                4: "DHW",
-                5: "Idle",
-                6: "Defrost",
-                7: "Stop",
-            }
-            return operation_status_map.get(value, f"Unknown ({value})")
+            if value is None:
+                return None
+            return OPERATION_STATUS_MAP.get(value, f"Unknown ({value})")
 
         if self._key == "system_status_flags":
             # Return as hex string for easier interpretation
@@ -1754,8 +1746,12 @@ class CSNetHomeCompressorSensor(CoordinatorEntity, Entity):
         if self._key == "operation_status":
             heating_status = self._get_heating_status()
             if heating_status:
+                raw_value = heating_status.get("operationStatus")
                 return {
-                    "raw_value": heating_status.get("operationStatus"),
+                    "raw_value": raw_value,
+                    "status_text": OPERATION_STATUS_MAP.get(
+                        raw_value, f"Unknown ({raw_value})"
+                    ),
                     "defrosting": bool(heating_status.get("defrosting", 0)),
                 }
 


### PR DESCRIPTION
## Summary
- reuse the shared `OPERATION_STATUS_MAP` to decode outdoor unit operation status values
- surface the mapped status text and defrost flag as attributes on the compressor operation sensor
- ensure outdoor operation states match CSNet JavaScript constants (0-11)

## Testing
- black
- codespell
- flake8
- bandit
- pylint
- mypy

Fixes Issue #122 
