### PR TITLE
Fix issue #131: Add temperature limits validation matching JavaScript logic

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1502,6 +1502,95 @@ def test_get_temperature_limits_partial_data(hass):
     assert max_temp is None  # Max not available
 
 
+def test_get_temperature_limits_validation_zero_value(hass):
+    """Test temperature limits validation when value is 0 (should use default)."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "heatAirMaxC1": 0,  # Invalid value, should use default
+            "heatAirMinC1": 11,
+        }
+    }
+
+    # Zone 1, heating mode (mode=1)
+    min_temp, max_temp = api.get_temperature_limits(1, 1, installation_devices_data)
+
+    assert min_temp == 11
+    assert max_temp == 35  # Should use HEATING_MAX_TEMPERATURE default (35°C)
+
+
+def test_get_temperature_limits_validation_negative_one(hass):
+    """Test temperature limits validation when value is -1 (should use default)."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "heatAirMaxC1": -1,  # Invalid value, should use default
+            "heatAirMinC1": 11,
+        }
+    }
+
+    # Zone 1, heating mode (mode=1)
+    min_temp, max_temp = api.get_temperature_limits(1, 1, installation_devices_data)
+
+    assert min_temp == 11
+    assert max_temp == 35  # Should use HEATING_MAX_TEMPERATURE default (35°C)
+
+
+def test_get_temperature_limits_validation_water_circuit_zero(hass):
+    """Test temperature limits validation for water circuit when value is 0."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "heatMaxC1": 0,  # Invalid value, should use default
+            "heatMinC1": 25,
+        }
+    }
+
+    # Zone 5, heating mode (mode=1)
+    min_temp, max_temp = api.get_temperature_limits(5, 1, installation_devices_data)
+
+    assert min_temp == 25
+    assert max_temp == 80  # Should use WATER_CIRCUIT_MAX_HEAT default (80°C)
+
+
+def test_get_temperature_limits_validation_dhw_zero(hass):
+    """Test temperature limits validation for DHW when value is 0."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "dhwMax": 0,  # Invalid value, should use default
+        }
+    }
+
+    # Zone 3 (DHW), heating mode (mode=1)
+    min_temp, max_temp = api.get_temperature_limits(3, 1, installation_devices_data)
+
+    assert min_temp is None  # DHW min is not provided by API
+    assert max_temp == 80  # Should use WATER_HEATER_MAX_TEMPERATURE default (80°C)
+
+
+def test_get_temperature_limits_validation_cooling_mode_zero(hass):
+    """Test temperature limits validation for cooling mode when value is 0."""
+    api = CSNetHomeAPI(hass, "user", "pass")
+
+    installation_devices_data = {
+        "heatingStatus": {
+            "coolAirMaxC1": 0,  # Invalid value, should use default
+            "coolAirMinC1": 16,
+        }
+    }
+
+    # Zone 1, cooling mode (mode=0)
+    min_temp, max_temp = api.get_temperature_limits(1, 0, installation_devices_data)
+
+    assert min_temp == 16
+    assert max_temp == 35  # Should use HEATING_MAX_TEMPERATURE default (35°C)
+
+
 # Fan Speed Control Tests
 @pytest.mark.asyncio
 async def test_api_set_fan_speed_c1_low(mock_aiohttp_client, hass):


### PR DESCRIPTION
## Description

This PR fixes issue #131 by adding the missing validation logic to the `get_temperature_limits` method to match the JavaScript `validateValue` function used in the CSNet Home website.

## Problem

The `get_temperature_limits` method was missing the validation logic present in the JavaScript website code. When the API returned invalid sentinel values (`0`, `-1`, or `None`) for temperature limits, these values were returned directly instead of being replaced with appropriate defaults. This could lead to invalid temperature limits being displayed to users.

The JavaScript code uses a `validateValue` function that checks:
```javascript
function validateValue(v, def) {
    if (v != null && v != undefined && v != 0 && v != -1)
        return v;
    return def;
}
```

## Solution

1. **Added `_validate_value` helper method** that implements the same validation logic as the JavaScript `validateValue` function
2. **Updated `get_temperature_limits` method** to validate all max temperature values using the new helper
3. **Applied appropriate defaults** based on zone type and mode:
   - Air circuits (zones 1, 2): `HEATING_MAX_TEMPERATURE` (35°C) - matches `RTU_MAX`
   - Water circuits heating (zones 5, 6): `WATER_CIRCUIT_MAX_HEAT` (80°C) - matches `C1_MAX_HEAT`/`C2_MAX_HEAT`
   - Water circuits cooling (zones 5, 6): `WATER_CIRCUIT_MAX_HEAT` (80°C) - note: `C1_MAX_COOL`/`C2_MAX_COOL` not in constants, using heat default
   - DHW (zone 3): `WATER_HEATER_MAX_TEMPERATURE` (80°C) - matches `DHW_MAX`

## Changes Made

### `custom_components/csnet_home/api.py`
- Added `_validate_value` helper method that validates temperature limit values
- Updated `get_temperature_limits` to use validation for all max temperature values
- Added imports for temperature limit constants (`HEATING_MAX_TEMPERATURE`, `WATER_CIRCUIT_MAX_HEAT`, `WATER_HEATER_MAX_TEMPERATURE`)

### `tests/test_api.py`
- Added `test_get_temperature_limits_validation_zero_value` - tests validation when value is `0`
- Added `test_get_temperature_limits_validation_negative_one` - tests validation when value is `-1`
- Added `test_get_temperature_limits_validation_water_circuit_zero` - tests validation for water circuits
- Added `test_get_temperature_limits_validation_dhw_zero` - tests validation for DHW
- Added `test_get_temperature_limits_validation_cooling_mode_zero` - tests validation for cooling mode

## Testing

All new tests pass and verify that:
- Values that are `None`, `0`, or `-1` return the appropriate default
- Valid values are returned as-is
- The validation only applies to max values (matching the JavaScript behavior where min values don't have defaults)

## Impact

- **Backward Compatible**: Valid temperature limit values continue to work as before
- **Improved Reliability**: Invalid sentinel values are now handled gracefully with sensible defaults
- **Consistency**: Behavior now matches the CSNet Home website JavaScript code

## Related Issue

Fixes #131

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests have been added for new functionality
- [x] All existing tests pass
- [x] Documentation has been updated (if needed)
- [x] Changes are backward compatible