### PR TITLE
Add manual override for Legacy Fan Coil support

### DIFF
--- a/custom_components/csnet_home/climate.py
+++ b/custom_components/csnet_home/climate.py
@@ -4,32 +4,32 @@ import asyncio
 import logging
 
 from homeassistant.components.climate import (
-    ClimateEntity,
-    HVACMode,
-    HVACAction,
     FAN_AUTO,
+    ClimateEntity,
+    HVACAction,
+    HVACMode,
 )
-from homeassistant.components.climate.const import ClimateEntityFeature, FAN_ON
+from homeassistant.components.climate.const import FAN_ON, ClimateEntityFeature
 from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import (
+    CONF_FAN_COIL_MODEL,
+    CONF_MAX_TEMP_OVERRIDE,
+    DEFAULT_FAN_COIL_MODEL,
     DOMAIN,
+    FAN_COIL_MODEL_LEGACY,
+    FAN_SPEED_MAP_LEGACY,
+    FAN_SPEED_MAP_STANDARD,
+    FAN_SPEED_REVERSE_MAP_LEGACY,
+    FAN_SPEED_REVERSE_MAP_STANDARD,
     HEATING_MAX_TEMPERATURE,
     HEATING_MIN_TEMPERATURE,
+    OPERATION_STATUS_MAP,
+    OTC_COOLING_TYPE_NAMES,
+    OTC_HEATING_TYPE_NAMES,
     WATER_CIRCUIT_MAX_HEAT,
     WATER_CIRCUIT_MIN_HEAT,
-    CONF_MAX_TEMP_OVERRIDE,
-    FAN_SPEED_MAP_STANDARD,
-    FAN_SPEED_REVERSE_MAP_STANDARD,
-    FAN_SPEED_MAP_LEGACY,
-    FAN_SPEED_REVERSE_MAP_LEGACY,
-    CONF_FAN_COIL_MODEL,
-    FAN_COIL_MODEL_LEGACY,
-    DEFAULT_FAN_COIL_MODEL,
-    OPERATION_STATUS_MAP,
-    OTC_HEATING_TYPE_NAMES,
-    OTC_COOLING_TYPE_NAMES,
 )
 from .helpers import extract_heating_status
 


### PR DESCRIPTION
This PR addresses an issue where certain older Yutaki with Fan Coils installed don't correctly report their Fan Coil capabilities via the API. This resulted in fan speed controls were hidden for users who actually have Fan Coil units.

**Changes**

1. Climate Logic (climate.py):

- If "Legacy" mode is selected, self._is_fan_coil is forced to True, bypassing the strict API capability check. If "Standard" is selected, the original automatic detection logic is preserved.

- Fan Control Command: In async_set_fan_mode, the code now skips the get_fan_control_availability check only if "Legacy" mode is active. This is necessary because the API incorrectly reports fan control as "unavailable" for these specific units.

**Motivation**

To allow users with older hardware to control their fan speeds without breaking the auto-detection logic for users with modern equipment.