### PR TITLE
Fix device_info KeyError causing HA crashes with Versatile Thermostat (Closes #140)

### DIFF
--- a/custom_components/csnet_home/sensor.py
+++ b/custom_components/csnet_home/sensor.py
@@ -879,15 +879,34 @@ class CSNetHomeSensor(CoordinatorEntity, Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
+        device_name = self._sensor_data.get("device_name", "Unknown Device")
+        room_name = self._sensor_data.get("room_name", "Unknown Room")
+        device_id = self._sensor_data.get("device_id")
+
+        # Handle both data structures:
+        # 1. Device-specific dict (initial): _common_data = {"name": "...", "firmware": "..."}
+        # 2. Full common_data dict (after update): _common_data = {"device_status": {...}}
+        if "device_status" in self._common_data:
+            # After update: nested structure
+            device_status = self._common_data.get("device_status", {}).get(
+                device_id, {}
+            )
+            device_name_from_status = device_status.get("name", "Unknown")
+            firmware = device_status.get("firmware")
+        else:
+            # Initial state: direct access
+            device_name_from_status = self._common_data.get("name", "Unknown")
+            firmware = self._common_data.get("firmware")
+
         return DeviceInfo(
-            name=f"{self._sensor_data['device_name']}-{self._sensor_data['room_name']}",
+            name=f"{device_name}-{room_name}",
             manufacturer="Hitachi",
-            model=f"{self._common_data['name']} Remote Controller",
-            sw_version=self._common_data["firmware"],
+            model=f"{device_name_from_status} Remote Controller",
+            sw_version=firmware,  # None is acceptable for DeviceInfo
             identifiers={
                 (
                     DOMAIN,
-                    f"{self._sensor_data['device_name']}-{self._sensor_data['room_name']}",
+                    f"{device_name}-{room_name}",
                 )
             },
         )


### PR DESCRIPTION
## Problem Description

The CSNet Home integration was causing Home Assistant crashes when used alongside the Versatile Thermostat integration. The crash occurred when Versatile Thermostat iterates through all climate entities to register them for central configuration.

### Root Cause

The `device_info` property in the CSNet Home climate and sensor entities used direct dictionary access (`self._common_data["firmware"]`) instead of defensive access methods. When the `firmware` key was missing from `_common_data`, a `KeyError` was raised, causing Home Assistant to crash.

**Error Traceback** (from [Versatile Thermostat issue #1300](https://github.com/jmcollin78/versatile_thermostat/issues/1300#issuecomment-3590625131)):
```
File "/config/custom_components/csnet_home/climate.py", line 264, in device_info
    sw_version=self._common_data["firmware"],
               ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'firmware'
```

### Critical Discovery

There's a **data structure inconsistency** in how `_common_data` is managed:

1. **During Initialization**: Climate and sensor entities receive a device-specific dict:
   ```python
   common_data = coordinator.get_common_data()["device_status"][device_id]
   # Results in: {"name": "...", "firmware": "..."}
   ```

2. **After Update** (in `async_update()`): `_common_data` is replaced with the full `common_data` dict:
   ```python
   self._common_data = coordinator.get_common_data()
   # Results in: {"device_status": {device_id: {"name": "...", "firmware": "..."}}}
   ```

This means:
- **Initially**: `_common_data["firmware"]` works (device-specific dict)
- **After update**: `_common_data["firmware"]` fails (firmware is now nested at `_common_data["device_status"][device_id]["firmware"]`)

## Solution

### Changes Made

1. **Fixed `device_info` in `CSNetHomeClimate` class** (`climate.py`):
   - Handle both data structure formats (device-specific dict vs full common_data dict)
   - Use defensive dictionary access with `.get()` and defaults
   - Provide sensible fallback values for missing data

2. **Fixed `device_info` in `CSNetHomeSensor` class** (`sensor.py`):
   - Same defensive approach as climate entity
   - Handle both data structure formats

3. **Added comprehensive tests**:
   - Test with complete data (initial state)
   - Test with missing firmware key
   - Test after update with nested structure
   - Test with missing device_status
   - Test with missing sensor_data keys

### Implementation Details

The fix makes `device_info` properties handle both data structures:

```python
@property
def device_info(self) -> DeviceInfo:
    """Return device information."""
    device_name = self._sensor_data.get("device_name", "Unknown Device")
    room_name = self._sensor_data.get("room_name", "Unknown Room")
    device_id = self._sensor_data.get("device_id")
    
    # Handle both data structures:
    # 1. Device-specific dict (initial): _common_data = {"name": "...", "firmware": "..."}
    # 2. Full common_data dict (after update): _common_data = {"device_status": {...}}
    if "device_status" in self._common_data:
        # After update: nested structure
        device_status = self._common_data.get("device_status", {}).get(device_id, {})
        device_name_from_status = device_status.get("name", "Unknown")
        firmware = device_status.get("firmware")
    else:
        # Initial state: direct access
        device_name_from_status = self._common_data.get("name", "Unknown")
        firmware = self._common_data.get("firmware")
    
    return DeviceInfo(
        name=f"{device_name}-{room_name}",
        manufacturer="Hitachi",
        model=f"{device_name_from_status} Remote Controller",
        sw_version=firmware,  # None is acceptable for DeviceInfo
        identifiers={(DOMAIN, f"{device_name}-{room_name}")},
    )
```

## Testing

- ✅ Added unit tests for all edge cases
- ✅ Tests cover both data structure formats
- ✅ Tests verify defensive behavior with missing keys
- ✅ All existing tests continue to pass

## Impact

- **Before**: Home Assistant crashes with `KeyError` when Versatile Thermostat accesses `device_info`
- **After**: `device_info` returns gracefully with sensible defaults, preventing crashes

## Related Issues

- Fixes: #140
- Related to: [Versatile Thermostat issue #1300](https://github.com/jmcollin78/versatile_thermostat/issues/1300)
- Analysis: [Comment #3591217772](https://github.com/jmcollin78/versatile_thermostat/issues/1300#issuecomment-3591217772)

## Benefits

- ✅ Prevents crashes and system instability
- ✅ Improves compatibility with other integrations that access `device_info`
- ✅ More resilient to API data inconsistencies
- ✅ Backward compatible (only changes behavior when data is missing)

---

**Note**: The Versatile Thermostat developer (jmcollin78) mentioned they will add try-catch around their code, but fixing the root cause in CSNet Home is the proper solution and will prevent similar issues with other integrations.