### PR TITLE
feat: Add waterOutlet3Temp (TWO3) external tank temperature sensor

### DIFF
--- a/custom_components/csnet_home/sensor.py
+++ b/custom_components/csnet_home/sensor.py
@@ -233,6 +233,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 coordinator,
                 global_device_data,
                 common_data,
+                "out_water_temperature_3",
+                "temperature",
+                UnitOfTemperature.CELSIUS,
+                "External Tank Temperature",
+            )
+        )
+        sensors.append(
+            CSNetHomeInstallationSensor(
+                coordinator,
+                global_device_data,
+                common_data,
                 "set_water_temperature",
                 "temperature",
                 UnitOfTemperature.CELSIUS,
@@ -966,6 +977,7 @@ class CSNetHomeInstallationSensor(CoordinatorEntity, Entity):
             "water_flow": ["waterFlow"],
             "in_water_temperature": ["waterInletTemp"],
             "out_water_temperature": ["waterOutletTemp"],
+            "out_water_temperature_3": ["waterOutlet3Temp"],
             "set_water_temperature": ["waterTempSetting"],
             "water_pressure": ["waterPressure"],
             "defrost": ["defrosting"],

--- a/tests/fixtures/api_responses/installation_devices.json
+++ b/tests/fixtures/api_responses/installation_devices.json
@@ -30,6 +30,7 @@
     "heatMaxC1": 55,
     "coolMinC1": 15,
     "coolMaxC1": 22,
-    "dhwMax": 60
+    "dhwMax": 60,
+    "waterOutlet3Temp": 25
   }
 }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -220,6 +220,7 @@ def test_installation_sensor():
                             "waterFlow": 39,  # Will be divided by 10
                             "waterInletTemp": 20,
                             "waterOutletTemp": 20,
+                            "waterOutlet3Temp": 25,
                             "waterTempSetting": 23,
                             "waterPressure": 224,  # Will be divided by 50
                             "gasTemp": 20,
@@ -307,6 +308,18 @@ def test_installation_sensor():
         "Liquid Temperature",
     )
     assert s.state == 20
+
+    # Test external tank temperature sensor (waterOutlet3Temp)
+    s = CSNetHomeInstallationSensor(
+        coordinator,
+        device_data,
+        common_data,
+        "out_water_temperature_3",
+        "temperature",
+        "°C",
+        "External Tank Temperature",
+    )
+    assert s.state == 25
 
 
 def test_installation_sensor_edge_cases():


### PR DESCRIPTION
# Add waterOutlet3Temp (TWO3) External Tank Temperature Sensor

## Summary
This PR implements support for the **waterOutlet3Temp (TWO3)** thermistor sensor that measures temperature in an external water tank for heating systems. This addresses issue #154 and enables accurate calculation of real water heater temperature even when the System Controller Pump Speed is 0.

## Problem Statement
Previously, the integration did not expose the TWO3 (waterOutlet3Temp) sensor, which is essential for:
- Accurately measuring the actual water heater outlet temperature
- Calculating real heating water temperature when System Controller Pump Speed is 0
- Providing complete system diagnostics for heat pump installations

## Solution
Added a new installation-level sensor that exposes the external water tank temperature from the CSNet API response.

## Changes Made

### 1. **custom_components/csnet_home/sensor.py**
- **Line 980**: Added `"out_water_temperature_3": ["waterOutlet3Temp"]` to the `key_mappings` dictionary in `CSNetHomeInstallationSensor.state` property
- **Lines 231-240**: Created new `CSNetHomeInstallationSensor` instance for external tank temperature sensor
  - Sensor Key: `out_water_temperature_3`
  - Device Class: `temperature`
  - Unit: `UnitOfTemperature.CELSIUS`
  - Friendly Name: "External Tank Temperature"

### 2. **tests/fixtures/api_responses/installation_devices.json**
- Added `"waterOutlet3Temp": 25` to the test fixture heatingStatus to support test coverage

### 3. **tests/test_sensor.py**
- **Line 223**: Added `"waterOutlet3Temp": 25` to test data structure
- **Lines 312-324**: Added unit test case to verify the sensor correctly reads waterOutlet3Temp value

## Technical Details

### Design Decisions
1. **Installation-Level Sensor**: Created as installation-level (not zone-specific) since the external tank is typically a system-wide component, making it available globally
2. **Friendly Name**: Used "External Tank Temperature" for user clarity about what the sensor measures
3. **No Data Transformation**: Returns raw temperature value directly from API (unlike water_flow/water_pressure which require division)
4. **Naming Convention**: Follows existing pattern with sensor key `out_water_temperature_3`

### API Integration
The sensor retrieves data from:
```
CSNet API Response → installation_devices → data[0].indoors[0].heatingStatus.waterOutlet3Temp
```

## User Impact

### New Entity
- **Entity ID**: `sensor.<device_name>_Controller_External Tank Temperature`
- **Unit**: °C (Celsius)
- **Available**: For all users with CSNet-connected Hitachi heat pump systems
- **Value**: External water tank temperature reading

### Use Cases
- Monitor external tank temperature in real-time
- Create automations based on tank temperature thresholds
- Diagnose heating system performance and efficiency
- Detect abnormal temperature conditions

## Testing
- ✅ Unit test added to verify sensor state retrieval
- ✅ Test fixture updated with sample data
- ✅ Follows existing test patterns for installation sensors
- ✅ No breaking changes to existing functionality

## Backward Compatibility
- ✅ Fully backward compatible
- ✅ Only adds new sensor, no modifications to existing ones
- ✅ No API changes or breaking changes

## Related Issues
- Closes #154: Add TWO3 thermistor sensor for external water tank temperature measurement
