### PR TITLE
fix: Restore missing implementation from PR #155 (new sensors + Spanish language)

### DIFF
--- a/custom_components/csnet_home/config_flow.py
+++ b/custom_components/csnet_home/config_flow.py
@@ -57,7 +57,7 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                     ): int,
                     vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
-                        ["en", "fr"]
+                        ["en", "fr", "es"]
                     ),
                     vol.Optional(CONF_MAX_TEMP_OVERRIDE): vol.All(
                         vol.Coerce(int), vol.Range(min=8, max=80)

--- a/custom_components/csnet_home/const.py
+++ b/custom_components/csnet_home/const.py
@@ -112,6 +112,7 @@ DEFAULT_LANGUAGE = "en"
 LANGUAGE_FILES = {
     "en": "english.json",
     "fr": "french.json",
+    "es": "spanish.json",
 }
 
 # OTC (Outdoor Temperature Compensation) Constants


### PR DESCRIPTION
## Summary

This PR restores the missing implementation from the merged PR #155 by @davigar1391.

Despite being merged, several critical pieces of code from [PR #155](https://github.com/mmornati/home-assistant-csnet-home/pull/155) were not carried over into `main`. The `async_setup_entry()` function already **registers** the new sensors (`CSNetHomeCalculatedSensor`, `CSNetHomeDailySensor`), but the **class definitions were never present** — this would cause a `NameError` crash on Home Assistant startup.

## Root Cause

PR #155 was submitted from a fork that had diverged significantly from main. The GitHub diff showed all files as "new" (from `/dev/null`), which likely caused the merge to only partially apply changes. The sensor registrations in `async_setup_entry()` were merged but the corresponding class definitions (364 lines) were not.

## Changes

### `sensor.py`

- ✅ **Add `CSNetHomeCalculatedSensor` class** — Calculates instantaneous sensors:
  - `instant_consumption`: Electricity power (W) using a physics-based model (Hz × ΔPressure × k_dynamic) with Amperage guardrails to keep the result within the real reported integer-Ampere range
  - `heating_power`: Heat output (W) from water flow rate and ΔTemperature
  - `instant_cop`: Coefficient of Performance (ratio)

- ✅ **Add `CSNetHomeDailySensor` class** — Accumulates energy daily with midnight reset and `RestoreEntity` support:
  - `daily_consumption` (kWh)
  - `daily_heating` (kWh)
  - `daily_cop_heating` — COP for Heating mode (op_status=6)
  - `daily_cop_dhw` — COP for DHW mode (op_status=8)

- ✅ **Add missing key mappings** in `CSNetHomeInstallationSensor`:
  - `bottom_dhw_temperature` → `bottomTempDHW`
  - `heat_exchanger_water_outlet_temperature` → `waterOutletHPTemp` (used to correctly measure DHW outlet temperature separate from heating outlet)

- ✅ **Register `ou_evo_1` sensor** — Expansion Valve Opening (EVO) sensor that was in the original PR but not registered

### `const.py`

- ✅ **Add Spanish language mapping**: `"es": "spanish.json"` to `LANGUAGE_FILES`

### `config_flow.py`

- ✅ **Add `"es"` to language dropdown** — Spanish is now selectable during integration setup

## New Sensors Added

| Sensor ID | Unit | Description |
|---|---|---|
| `instant_consumption` | W | Instant electrical power consumed |
| `heating_power` | W | Instant thermal output power |
| `instant_cop` | — | Instant Coefficient of Performance |
| `daily_consumption` | kWh | Daily electrical energy (resets at midnight) |
| `daily_heating` | kWh | Daily thermal energy (resets at midnight) |
| `daily_cop_heating` | — | Daily COP for space heating |
| `daily_cop_dhw` | — | Daily COP for domestic hot water |
| `heat_exchanger_water_outlet_temperature` | °C | Water outlet temp at heat exchanger (for DHW) |
| `ou_evo_1` | % | Outdoor unit expansion valve opening (EVO) |

## Credit

All implementation logic is from the original contribution by @davigar1391 in [PR #155](https://github.com/mmornati/home-assistant-csnet-home/pull/155). This PR only ensures that work actually lands in `main`.

## Testing

- ✅ Python syntax check passes
- ✅ All pre-commit hooks pass (black, isort, flake8, pylint, mypy, codespell, bandit)
