### PR TITLE
Remove unused is_yutaki method

### DIFF
--- a/custom_components/csnet_home/api.py
+++ b/custom_components/csnet_home/api.py
@@ -1334,13 +1334,6 @@ class CSNetHomeAPI:
         # Default to standard air unit
         return "standard"
 
-    def is_yutaki(
-        self, sensor_data: dict, installation_devices_data: dict = None
-    ) -> bool:
-        """Check if unit is a Yutaki (water module) system."""
-        unit_type = self.get_unit_type(sensor_data, installation_devices_data)
-        return unit_type in ["yutaki", "water_heater"]
-
     def get_alarm_origin(
         self, alarm_code: int, unit_type: str, installation_devices_data: dict = None
     ) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2067,23 +2067,6 @@ def test_get_unit_type(hass):
     assert api.get_unit_type(sensor_data, installation_data) == "standard"
 
 
-def test_is_yutaki(hass):
-    """Test Yutaki system detection."""
-    api = CSNetHomeAPI(hass, "user", "pass")
-
-    # Test with yutaki zone
-    sensor_data = {"zone_id": 5}
-    assert api.is_yutaki(sensor_data, None) is True
-
-    # Test with water heater zone
-    sensor_data = {"zone_id": 3}
-    assert api.is_yutaki(sensor_data, None) is True
-
-    # Test with standard zone
-    sensor_data = {"zone_id": 1}
-    assert api.is_yutaki(sensor_data, None) is False
-
-
 def test_get_alarm_origin(hass):
     """Test alarm origin detection."""
     api = CSNetHomeAPI(hass, "user", "pass")


### PR DESCRIPTION
Remove unused `is_yutaki` method from `custom_components/csnet_home/api.py` and its corresponding test `test_is_yutaki` from `tests/test_api.py`.
The method was not used anywhere in the codebase (verified via grep).
Existing tests pass (synchronously), async tests were skipped due to environment limitations but changes are trivial and low risk.


---
*PR created automatically by Jules for task [9963483424480285876](https://jules.google.com/task/9963483424480285876) started by @mmornati*