### PR TITLE
Refactor get_temperature_limits to use configuration map

### DIFF
--- a/custom_components/csnet_home/api.py
+++ b/custom_components/csnet_home/api.py
@@ -54,12 +54,8 @@ TEMPERATURE_LIMIT_CONFIGS = {
         "coolAirMaxC2",
         HEATING_MAX_TEMPERATURE,
     ),
-    5: TemperatureLimitConfig(
-        "heatMinC1", "heatMaxC1", "coolMinC1", "coolMaxC1", WATER_CIRCUIT_MAX_HEAT
-    ),
-    6: TemperatureLimitConfig(
-        "heatMinC2", "heatMaxC2", "coolMinC2", "coolMaxC2", WATER_CIRCUIT_MAX_HEAT
-    ),
+    5: TemperatureLimitConfig("heatMinC1", "heatMaxC1", "coolMinC1", "coolMaxC1", WATER_CIRCUIT_MAX_HEAT),
+    6: TemperatureLimitConfig("heatMinC2", "heatMaxC2", "coolMinC2", "coolMaxC2", WATER_CIRCUIT_MAX_HEAT),
 }
 
 TO_REDACT = {


### PR DESCRIPTION
Replaced the complex if/elif chain in `get_temperature_limits` with a configuration-driven approach using `TemperatureLimitConfig` dataclass and `TEMPERATURE_LIMIT_CONFIGS` dictionary for standard zones (1, 2, 5, 6).
Zone 3 (DHW) and Zone 4 (SWP) logic is preserved explicitly as they do not follow the standard heating/cooling pattern.
This improves readability and maintainability of the code.

Verification:
- Created a standalone test script mocking dependencies to verify `get_temperature_limits` logic for all zones and modes.
- Confirmed that Zone 3 still uses `dhwMax` regardless of mode.
- Confirmed that Zone 4 still returns fixed range (24, 33).
- Confirmed that standard zones use correct keys based on mode.
- Ran `black` to ensure code style compliance.

---
*PR created automatically by Jules for task [5746112524389812518](https://jules.google.com/task/5746112524389812518) started by @mmornati*