### PR TITLE
⚡ Optimize CSNetHomeClimate by inheriting from CoordinatorEntity

### DIFF
--- a/custom_components/csnet_home/climate.py
+++ b/custom_components/csnet_home/climate.py
@@ -7,6 +7,7 @@ from homeassistant.components.climate import FAN_AUTO, ClimateEntity, HVACAction
 from homeassistant.components.climate.const import FAN_ON, ClimateEntityFeature
 from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     CONF_FAN_COIL_MODEL,
@@ -43,7 +44,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(
         [
             CSNetHomeClimate(
-                hass,
+                coordinator,
                 entry,
                 sensor_data=sensor_data,
                 common_data=coordinator.get_common_data()["device_status"][sensor_data["device_id"]],
@@ -54,12 +55,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     )
 
 
-class CSNetHomeClimate(ClimateEntity):
+class CSNetHomeClimate(CoordinatorEntity, ClimateEntity):
     """Representation of a thermostat (climate) entity."""
 
-    def __init__(self, hass, entry, sensor_data, common_data):
+    def __init__(self, coordinator, entry, sensor_data, common_data):
         """Initialize the thermostat entity."""
-        self.hass = hass
+        super().__init__(coordinator)
+        self.hass = coordinator.hass
         self._sensor_data = sensor_data
         self._common_data = common_data
         self._attr_name = self._sensor_data.get("room_name", "Unknown")
@@ -79,9 +81,8 @@ class CSNetHomeClimate(ClimateEntity):
         else:
             self._attr_preset_mode = "comfort"
 
-        coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
-        installation_devices_data = coordinator.get_installation_devices_data()
-        cloud_api = self.hass.data[DOMAIN][self.entry.entry_id]["api"]
+        installation_devices_data = self.coordinator.get_installation_devices_data()
+        cloud_api = self.coordinator.hass.data[DOMAIN][self.entry.entry_id]["api"]
 
         # Determine Fan Coil type from config
         self._fan_model = self.entry.data.get(CONF_FAN_COIL_MODEL, DEFAULT_FAN_COIL_MODEL)
@@ -198,7 +199,7 @@ class CSNetHomeClimate(ClimateEntity):
         # For water circuits (zone 5, 6), only return target temperature if OTC type is FIX
         if zone_id in [5, 6]:  # Water circuits (C1_WATER, C2_WATER)
             # Get installation devices data to check OTC type
-            coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+            coordinator = self.coordinator
             installation_devices_data = coordinator.get_installation_devices_data()
 
             if installation_devices_data:
@@ -308,7 +309,7 @@ class CSNetHomeClimate(ClimateEntity):
         }
 
         # Get installation devices data (used by both fan coil and OTC)
-        coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+        coordinator = self.coordinator
         installation_devices_data = coordinator.get_installation_devices_data()
 
         # Add fan speed information for fan coil systems
@@ -364,7 +365,7 @@ class CSNetHomeClimate(ClimateEntity):
         # For water circuits (zone 5, 6), only allow temperature changes if OTC type is FIX
         if zone_id in [5, 6]:  # Water circuits (C1_WATER, C2_WATER)
             # Get installation devices data to check OTC type
-            coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+            coordinator = self.coordinator
             installation_devices_data = coordinator.get_installation_devices_data()
 
             if installation_devices_data:
@@ -398,7 +399,7 @@ class CSNetHomeClimate(ClimateEntity):
                 # Wait a short delay to ensure the server has processed the change
                 await asyncio.sleep(1.5)
                 # Request coordinator refresh to update the value immediately
-                coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+                coordinator = self.coordinator
                 await coordinator.async_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode):
@@ -457,7 +458,7 @@ class CSNetHomeClimate(ClimateEntity):
             circuit = 1 if zone_id == 1 else 2
 
             # Check if fan control is available for this circuit
-            coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+            coordinator = self.coordinator
             installation_devices_data = coordinator.get_installation_devices_data()
             mode = self._sensor_data.get("mode", 1)
             # Skip the API check if the user has selected Legacy
@@ -511,16 +512,12 @@ class CSNetHomeClimate(ClimateEntity):
             and self._sensor_data.get("setting_temperature") < self._sensor_data.get("current_temperature")
         )
 
-    async def async_update(self):
-        """Update the thermostat data from the API."""
-        _LOGGER.debug("Updating CSNet Home refresh request %s", self._attr_name)
-        coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
-        if not coordinator:
-            _LOGGER.error("No coordinator instance found!")
-            return
-        await coordinator.async_request_refresh()
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        _LOGGER.debug("Updating CSNet Home data for %s", self._attr_name)
+
         self._sensor_data = next(
-            (x for x in coordinator.get_sensors_data() if x.get("room_name") == self._attr_name),
+            (x for x in self.coordinator.get_sensors_data() if x.get("room_name") == self._attr_name),
             None,
         )
         if self._sensor_data is None:
@@ -540,9 +537,10 @@ class CSNetHomeClimate(ClimateEntity):
         else:
             self._assumed_fan_mode = api_fan_mode
 
-        self._common_data = coordinator.get_common_data()
+        self._common_data = self.coordinator.get_common_data()
         # reset cached limits after data refresh
         self._cached_limits = None
+        self.async_write_ha_state()
 
     def _normalize_temperature_limit(self, value: float | int | None) -> float | None:
         """Convert raw API limit values to Celsius and validate."""
@@ -580,7 +578,7 @@ class CSNetHomeClimate(ClimateEntity):
         min_limit = default_min
         max_limit = default_max
 
-        coordinator = self.hass.data[DOMAIN][self.entry.entry_id]["coordinator"]
+        coordinator = self.coordinator
         installation_devices_data = coordinator.get_installation_devices_data()
 
         if installation_devices_data:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -106,14 +106,16 @@ def build_entity(
         get_fan_control_availability=lambda circuit, mode, data: is_fan_coil,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: installation_devices_data,
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     return entity
 
 
@@ -225,8 +227,8 @@ def test_unique_id_contains_device_id(hass):
 
 
 @pytest.mark.asyncio
-async def test_async_update_handles_missing_sensor_data(hass):
-    """Test that async_update handles when sensor data becomes None gracefully."""
+async def test_handle_coordinator_update_handles_missing_sensor_data(hass):
+    """Test that _handle_coordinator_update handles when sensor data becomes None gracefully."""
     entity = build_entity(hass, mode=1, on_off=1, cur=19.5, setp=20.0)
 
     # Modify coordinator to return empty list (simulating room not found)
@@ -234,7 +236,7 @@ async def test_async_update_handles_missing_sensor_data(hass):
     coordinator.get_sensors_data = lambda: []
 
     # This should not raise TypeError even though sensor_data becomes None
-    await entity.async_update()
+    entity._handle_coordinator_update()
 
     # Verify entity handles None sensor_data gracefully
     assert entity.current_temperature is None
@@ -248,12 +250,15 @@ async def test_async_update_handles_missing_sensor_data(hass):
 
 
 @pytest.mark.asyncio
-async def test_async_update_preserves_sensor_data_when_found(hass):
-    """Test that async_update works correctly when sensor data is found."""
+async def test_handle_coordinator_update_preserves_sensor_data_when_found(hass):
+    """Test that _handle_coordinator_update works correctly when sensor data is found."""
     entity = build_entity(hass, mode=1, on_off=1, cur=19.5, setp=20.0)
 
+    # Mock async_write_ha_state to avoid platform requirement in tests
+    entity.async_write_ha_state = lambda: None
+
     # Update should preserve the sensor data
-    await entity.async_update()
+    entity._handle_coordinator_update()
 
     # Verify entity still has valid data
     assert entity.current_temperature == 19.5
@@ -363,7 +368,9 @@ def test_dynamic_temperature_limits_heating_mode(hass):
     )
 
     hass.data[DOMAIN][entity.entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entity.entry.entry_id]["coordinator"] = mock_coordinator
+    entity.coordinator = mock_coordinator
 
     # Test min and max temperature
     assert entity.min_temp == 11
@@ -395,7 +402,9 @@ def test_dynamic_temperature_limits_cooling_mode(hass):
     )
 
     hass.data[DOMAIN][entity.entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entity.entry.entry_id]["coordinator"] = mock_coordinator
+    entity.coordinator = mock_coordinator
 
     # Test min and max temperature for cooling mode
     assert entity.min_temp == 16
@@ -422,7 +431,9 @@ def test_dynamic_temperature_limits_fallback_to_defaults(hass):
     )
 
     hass.data[DOMAIN][entity.entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entity.entry.entry_id]["coordinator"] = mock_coordinator
+    entity.coordinator = mock_coordinator
 
     # Test that defaults are used
     assert entity.min_temp == HEATING_MIN_TEMPERATURE
@@ -485,9 +496,10 @@ def test_dynamic_temperature_limits_zone2(hass):
     )
 
     hass.data[DOMAIN][entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entry.entry_id]["coordinator"] = mock_coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(mock_coordinator, entry, sensor_data, common_data)
 
     # Test min and max temperature for zone 2
     assert entity.min_temp == 12
@@ -552,9 +564,10 @@ def test_max_temp_override_in_config(hass):
     )
 
     hass.data[DOMAIN][entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entry.entry_id]["coordinator"] = mock_coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(mock_coordinator, entry, sensor_data, common_data)
 
     # Test that override value is used (45°C instead of API limit 30°C or default 35°C)
     assert entity.min_temp == 11  # Min is not overridden
@@ -619,9 +632,10 @@ def test_max_temp_no_override(hass):
     )
 
     hass.data[DOMAIN][entry.entry_id]["api"] = mock_api
+    mock_coordinator.hass = hass
     hass.data[DOMAIN][entry.entry_id]["coordinator"] = mock_coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(mock_coordinator, entry, sensor_data, common_data)
 
     # Test that API value is used (30°C from API)
     assert entity.max_temp == 30
@@ -971,14 +985,16 @@ def test_otc_attributes_zone1_heating_fix(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: installation_devices_data,
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     attrs = entity.extra_state_attributes
 
     # Verify OTC attributes are present for zone 1 (circuit 1)
@@ -1044,14 +1060,16 @@ def test_otc_attributes_zone2_heating_gradient(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: installation_devices_data,
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     attrs = entity.extra_state_attributes
 
     # Verify OTC attributes are present for zone 2 (circuit 2)
@@ -1117,14 +1135,16 @@ def test_otc_attributes_zone5_water_circuit(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: installation_devices_data,
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     attrs = entity.extra_state_attributes
 
     # Verify OTC attributes are present for zone 5 (circuit 1 water)
@@ -1180,14 +1200,16 @@ def test_otc_attributes_no_installation_data(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: None,  # No installation data
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     attrs = entity.extra_state_attributes
 
     # Verify OTC attributes are not present when no installation data
@@ -1249,14 +1271,16 @@ def test_otc_attributes_zone3_dhw_no_otc(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: installation_devices_data,
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     attrs = entity.extra_state_attributes
 
     # Verify OTC attributes are NOT present for zone 3 (DHW has no circuits)
@@ -1321,14 +1345,16 @@ def test_device_info_with_missing_firmware(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: {},
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     device_info = entity.device_info
 
     # Should not raise KeyError, firmware should be None
@@ -1389,14 +1415,16 @@ def test_device_info_with_missing_sensor_data_keys(hass):
         get_fan_control_availability=lambda circuit, mode, data: False,
         get_temperature_limits=lambda zone_id, mode, data: (None, None),
     )
-    hass.data[DOMAIN][entry.entry_id]["coordinator"] = SimpleNamespace(
+    coordinator = SimpleNamespace(
         get_sensors_data=lambda: [sensor_data],
         get_common_data=lambda: {"device_status": {1234: common_data}},
         get_installation_devices_data=lambda: {},
         async_request_refresh=AsyncMock(return_value=None),
+        hass=hass,
     )
+    hass.data[DOMAIN][entry.entry_id]["coordinator"] = coordinator
 
-    entity = CSNetHomeClimate(hass, entry, sensor_data, common_data)
+    entity = CSNetHomeClimate(coordinator, entry, sensor_data, common_data)
     device_info = entity.device_info
 
     # Should not raise KeyError, should use defaults


### PR DESCRIPTION
💡 **What:**
- Changed `CSNetHomeClimate` to inherit from `CoordinatorEntity` instead of just `ClimateEntity`.
- Removed `async_update` method which was manually calling `coordinator.async_request_refresh()`.
- Implemented `_handle_coordinator_update` to process updates pushed by the coordinator.
- Updated `__init__` to accept `coordinator` and initialize `CoordinatorEntity`.
- Updated `async_setup_entry` to pass `coordinator` to the entity.
- Updated `tests/test_climate.py` to match the new constructor signature and verify `CoordinatorEntity` behavior (mocking necessary parts).

🎯 **Why:**
- Previously, `CSNetHomeClimate` triggered a full API refresh (`coordinator.async_request_refresh()`) every time Home Assistant polled the entity (every 30-60 seconds usually). This caused excessive and redundant API calls if multiple entities were active or if the poll interval was short.
- By inheriting from `CoordinatorEntity`, the entity now passively waits for the coordinator to fetch data (at its defined interval) and then updates its state. This significantly reduces API load and aligns with Home Assistant best practices for `DataUpdateCoordinator`.

📊 **Measured Improvement:**
- A reproduction test `tests/test_performance.py` (created and then deleted) confirmed that `async_request_refresh` is no longer called upon update, whereas it was called in the previous implementation.
- The `should_poll` property (inherited from `CoordinatorEntity`) now defaults to `False`, preventing Home Assistant from polling the entity unnecessarily.


---
*PR created automatically by Jules for task [7436790370196595578](https://jules.google.com/task/7436790370196595578) started by @mmornati*