### PR TITLE
🧪 Add tests for CSNet Home number entity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,15 +45,18 @@ try:
 except ImportError:
     sys.modules["async_timeout"] = MagicMock()
 
+
 @pytest.fixture
 def load_fixture():
     """Fixture to load test fixtures from the fixtures directory."""
     return _load_fixture
 
+
 @pytest.fixture
 def enable_custom_integrations():
     """Mock fixture for enabling custom integrations."""
     yield
+
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):


### PR DESCRIPTION
This PR adds a test suite for the `CSNetHomeFixedWaterTemperatureNumber` entity and its setup logic.

🎯 **What:**
- Created `tests/test_number.py` with 12 test cases.
- Improved `tests/conftest.py` to support running tests in environments where `homeassistant` or other dependencies are missing (e.g. some CI/dev containers).

📊 **Coverage:**
- `async_setup_entry`: Verified successful entity creation for Heating/Cooling C1/C2 when OTC type is FIX.
- `async_setup_entry`: Verified graceful exit when coordinator or data is missing, or OTC type is not FIX.
- `CSNetHomeFixedWaterTemperatureNumber`: Verified properties (`native_value`, `available`, `device_info`).
- `async_set_native_value`: Verified API call parameters, success path (refresh coordinator), and failure path (no refresh).
- `_handle_coordinator_update`: Verified sensor data update logic.

✨ **Result:**
- Increased test coverage for the number platform.
- Enabled unit tests to run in restricted development environments.

---
*PR created automatically by Jules for task [17155153019762829696](https://jules.google.com/task/17155153019762829696) started by @mmornati*