### PR TITLE
fix(ci): add Python 3.14 detection for nightly compatibility tests

### DIFF
--- a/.github/workflows/nightly-compatibility.yaml
+++ b/.github/workflows/nightly-compatibility.yaml
@@ -50,7 +50,9 @@ jobs:
           echo "Python requirement: $PY_REQ"
 
           # Determine Python version to use
-          if [[ "$PY_REQ" == *"3.13"* ]]; then
+          if [[ "$PY_REQ" == *"3.14"* ]]; then
+            PYTHON_VERSION="3.14"
+          elif [[ "$PY_REQ" == *"3.13"* ]]; then
             PYTHON_VERSION="3.13"
           else
             PYTHON_VERSION="3.12"
@@ -272,9 +274,12 @@ jobs:
           echo "HA $VERSION requires: $PY_REQ"
 
           # Map requirement to Python version to install
-          # HA 2025.6+ requires Python 3.13.2+
+          # HA 2026.3+ requires Python 3.14.2+
+          # HA 2025.6-2026.2 requires Python 3.13.2+
           # HA 2024.12-2025.5 requires Python 3.12+
-          if [[ "$PY_REQ" == *"3.13"* ]]; then
+          if [[ "$PY_REQ" == *"3.14"* ]]; then
+            PYTHON_VERSION="3.14"
+          elif [[ "$PY_REQ" == *"3.13"* ]]; then
             PYTHON_VERSION="3.13"
           else
             PYTHON_VERSION="3.12"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -90,7 +90,12 @@ jobs:
           echo "HA $VERSION requires: $PY_REQ"
 
           # Determine Python version
-          if [[ "$PY_REQ" == *"3.13"* ]]; then
+          # HA 2026.3+ requires Python 3.14.2+
+          # HA 2025.6-2026.2 requires Python 3.13.2+
+          # HA 2024.12-2025.5 requires Python 3.12+
+          if [[ "$PY_REQ" == *"3.14"* ]]; then
+            PYTHON_VERSION="3.14"
+          elif [[ "$PY_REQ" == *"3.13"* ]]; then
             PYTHON_VERSION="3.13"
           else
             PYTHON_VERSION="3.12"


### PR DESCRIPTION
## Summary

Fixes the nightly compatibility workflow failing with "No matching distribution found for homeassistant==2026.4.2" by adding proper Python 3.14 version detection. Also fixes the same issue in the PR smoke-test workflow.

## Problem

The nightly compatibility check workflow was failing every night on the "Test Against Latest HA Stable" job because:

1. **Home Assistant 2026.3+ requires Python >=3.14.2** (confirmed from PyPI metadata)
2. The workflow's Python version detection only checked for `3.13` in the `requires_python` field
3. When `requires_python` contains "3.14", the check `[[ "$PY_REQ" == *"3.13"* ]]` returns false
4. The logic falls through to `PYTHON_VERSION="3.12"`
5. pip cannot install `homeassistant==2026.3.4` or `homeassistant==2026.4.2` on Python 3.12 → **FAILS** with "No matching distribution found"

## Root Cause

The original detection logic only handled two cases:
```yaml
if [[ "$PY_REQ" == *"3.13"* ]]; then
  PYTHON_VERSION="3.13"
else
  PYTHON_VERSION="3.12"
fi
```

This doesn't account for Python 3.14 requirement introduced in HA 2026.3+.

## Solution

Add Python 3.14 detection before Python 3.13 in all affected workflows:

```yaml
if [[ "$PY_REQ" == *"3.14"* ]]; then
  PYTHON_VERSION="3.14"
elif [[ "$PY_REQ" == *"3.13"* ]]; then
  PYTHON_VERSION="3.13"
else
  PYTHON_VERSION="3.12"
fi
```

## Changes

| File | Lines | Change |
|------|-------|--------|
| `.github/workflows/nightly-compatibility.yaml` | 52-60 | Add `3.14` check in `test-latest-stable` job |
| `.github/workflows/nightly-compatibility.yaml` | 283-291 | Add `3.14` check in `smoke-test-multiple-versions` job |
| `.github/workflows/smoke-test.yaml` | 92-100 | Add `3.14` check in smoke-test job |

## Verification

Python 3.14 is available in GitHub Actions:
- Version 3.14.0+ is published to actions/python-versions
- Used by many projects that need Python 3.14 for their own releases