### PR TITLE
Feature: Add configurable alarm notification filtering (#193)

### DIFF
--- a/custom_components/csnet_home/__init__.py
+++ b/custom_components/csnet_home/__init__.py
@@ -9,7 +9,14 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from custom_components.csnet_home.api import CSNetHomeAPI
-from custom_components.csnet_home.const import CONF_LANGUAGE, DOMAIN
+from custom_components.csnet_home.const import (
+    CONF_ENABLE_ALARM_NOTIFICATIONS,
+    CONF_FILTERED_ALARM_CODES,
+    CONF_LANGUAGE,
+    DEFAULT_ENABLE_ALARM_NOTIFICATIONS,
+    DEFAULT_FILTERED_ALARM_CODES,
+    DOMAIN,
+)
 from custom_components.csnet_home.coordinator import CSNetHomeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,7 +53,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     api.preferred_language = entry.data.get(CONF_LANGUAGE)
 
     _LOGGER.debug("Starting CSNet Home sensor setup")
-    coordinator = CSNetHomeCoordinator(hass, entry.data.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL), entry.entry_id)
+    coordinator = CSNetHomeCoordinator(
+        hass,
+        entry.data.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL),
+        entry.entry_id,
+        entry.data.get(CONF_ENABLE_ALARM_NOTIFICATIONS, DEFAULT_ENABLE_ALARM_NOTIFICATIONS),
+        entry.data.get(CONF_FILTERED_ALARM_CODES, DEFAULT_FILTERED_ALARM_CODES),
+    )
 
     # Initialise a listener for config flow options changes.
     # See config_flow for defining an options setting that shows up as configure on the integration.

--- a/custom_components/csnet_home/config_flow.py
+++ b/custom_components/csnet_home/config_flow.py
@@ -7,10 +7,14 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 
 from .const import (
+    CONF_ENABLE_ALARM_NOTIFICATIONS,
     CONF_FAN_COIL_MODEL,
+    CONF_FILTERED_ALARM_CODES,
     CONF_LANGUAGE,
     CONF_MAX_TEMP_OVERRIDE,
+    DEFAULT_ENABLE_ALARM_NOTIFICATIONS,
     DEFAULT_FAN_COIL_MODEL,
+    DEFAULT_FILTERED_ALARM_CODES,
     DEFAULT_LANGUAGE,
     DOMAIN,
     FAN_COIL_MODEL_LEGACY,
@@ -48,8 +52,9 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                         CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
                         CONF_MAX_TEMP_OVERRIDE: user_input.get(CONF_MAX_TEMP_OVERRIDE),
-                        # Store the Fan coil control type
                         CONF_FAN_COIL_MODEL: user_input.get(CONF_FAN_COIL_MODEL, DEFAULT_FAN_COIL_MODEL),
+                        CONF_ENABLE_ALARM_NOTIFICATIONS: user_input.get(CONF_ENABLE_ALARM_NOTIFICATIONS, DEFAULT_ENABLE_ALARM_NOTIFICATIONS),
+                        CONF_FILTERED_ALARM_CODES: user_input.get(CONF_FILTERED_ALARM_CODES, DEFAULT_FILTERED_ALARM_CODES),
                     },
                 )
 
@@ -62,12 +67,14 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
                     vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(["en", "fr", "es"]),
                     vol.Optional(CONF_MAX_TEMP_OVERRIDE): vol.All(vol.Coerce(int), vol.Range(min=8, max=80)),
-                    # Selection of Fan coil control type
                     vol.Optional(CONF_FAN_COIL_MODEL, default=DEFAULT_FAN_COIL_MODEL): vol.In([FAN_COIL_MODEL_STANDARD, FAN_COIL_MODEL_LEGACY]),
+                    vol.Optional(CONF_ENABLE_ALARM_NOTIFICATIONS, default=DEFAULT_ENABLE_ALARM_NOTIFICATIONS): bool,
+                    vol.Optional(CONF_FILTERED_ALARM_CODES, default=DEFAULT_FILTERED_ALARM_CODES): str,
                 }
             ),
             description_placeholders={
-                "max_temp_override_desc": "Optional: Override maximum temperature limit (8-80°C). Leave empty to use device defaults (35°C for air circuits, 80°C for water circuits/heaters)."
+                "max_temp_override_desc": "Optional: Override maximum temperature limit (8-80°C). Leave empty to use device defaults (35°C for air circuits, 80°C for water circuits/heaters).",
+                "filtered_alarm_codes_desc": "Comma-separated list of alarm codes to suppress from notifications (default: -1 for communication errors). Leave empty to show all notifications.",
             },
             errors=errors,
         )
@@ -122,6 +129,8 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
                         CONF_MAX_TEMP_OVERRIDE: user_input.get(CONF_MAX_TEMP_OVERRIDE),
                         CONF_FAN_COIL_MODEL: user_input.get(CONF_FAN_COIL_MODEL, DEFAULT_FAN_COIL_MODEL),
+                        CONF_ENABLE_ALARM_NOTIFICATIONS: user_input.get(CONF_ENABLE_ALARM_NOTIFICATIONS, DEFAULT_ENABLE_ALARM_NOTIFICATIONS),
+                        CONF_FILTERED_ALARM_CODES: user_input.get(CONF_FILTERED_ALARM_CODES, DEFAULT_FILTERED_ALARM_CODES),
                     },
                 )
 
@@ -148,9 +157,20 @@ class CsnetHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_FAN_COIL_MODEL,
                         default=reconfigure_entry.data.get(CONF_FAN_COIL_MODEL, DEFAULT_FAN_COIL_MODEL),
                     ): vol.In([FAN_COIL_MODEL_STANDARD, FAN_COIL_MODEL_LEGACY]),
+                    vol.Optional(
+                        CONF_ENABLE_ALARM_NOTIFICATIONS,
+                        default=reconfigure_entry.data.get(CONF_ENABLE_ALARM_NOTIFICATIONS, DEFAULT_ENABLE_ALARM_NOTIFICATIONS),
+                    ): bool,
+                    vol.Optional(
+                        CONF_FILTERED_ALARM_CODES,
+                        default=reconfigure_entry.data.get(CONF_FILTERED_ALARM_CODES, DEFAULT_FILTERED_ALARM_CODES),
+                    ): str,
                 }
             ),
-            description_placeholders={"max_temp_override_desc": "Optional: Override maximum temperature limit (8-80°C). Leave empty to use device defaults."},
+            description_placeholders={
+                "max_temp_override_desc": "Optional: Override maximum temperature limit (8-80°C). Leave empty to use device defaults.",
+                "filtered_alarm_codes_desc": "Comma-separated list of alarm codes to suppress from notifications.",
+            },
             errors=errors,
         )
 

--- a/custom_components/csnet_home/const.py
+++ b/custom_components/csnet_home/const.py
@@ -11,9 +11,13 @@ HEAT_SETTINGS_PATH = "/data/indoor/heat_setting"
 CONF_ENABLE_DEVICE_LOGGING = "enable_device_logging"
 CONF_MAX_TEMP_OVERRIDE = "max_temp_override"
 CONF_FAN_COIL_MODEL = "fan_coil_model"
+CONF_ENABLE_ALARM_NOTIFICATIONS = "enable_alarm_notifications"
+CONF_FILTERED_ALARM_CODES = "filtered_alarm_codes"
 FAN_COIL_MODEL_STANDARD = "standard"
 FAN_COIL_MODEL_LEGACY = "legacy"
 DEFAULT_FAN_COIL_MODEL = FAN_COIL_MODEL_STANDARD
+DEFAULT_ENABLE_ALARM_NOTIFICATIONS = True
+DEFAULT_FILTERED_ALARM_CODES = "-1"
 
 COMMON_API_HEADERS = {
     "accept-language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",

--- a/custom_components/csnet_home/coordinator.py
+++ b/custom_components/csnet_home/coordinator.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 class CSNetHomeCoordinator(DataUpdateCoordinator):
     """Coordinator to fetch all sensor data from the cloud API."""
 
-    def __init__(self, hass: HomeAssistant, update_interval: int, entry_id: str):
+    def __init__(self, hass: HomeAssistant, update_interval: int, entry_id: str, enable_alarm_notifications: bool = True, filtered_alarm_codes: str = "-1"):
         """Initialize the coordinator."""
         _LOGGER.debug("Configuring CSNetHome Coordinator")
         self.hass = hass
@@ -25,6 +25,8 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
         self._sensors_by_id = {}
         self._last_alarm_codes: dict[str, int] = {}
         self._notified_installation_alarm_ids: set[int] = set()
+        self._enable_alarm_notifications = enable_alarm_notifications
+        self._filtered_alarm_codes = self._parse_filtered_alarm_codes(filtered_alarm_codes)
         super().__init__(
             hass,
             _LOGGER,
@@ -32,6 +34,16 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
             update_method=self._async_update_data,
             update_interval=self.update_interval,
         )
+
+    def _parse_filtered_alarm_codes(self, codes_string: str) -> set[int]:
+        """Parse comma-separated alarm codes string into a set of integers."""
+        if not codes_string:
+            return set()
+        try:
+            return {int(code.strip()) for code in codes_string.split(",") if code.strip()}
+        except ValueError:
+            _LOGGER.warning("Invalid alarm codes format: %s, defaulting to empty set", codes_string)
+            return set()
 
     async def _async_update_data(self):
         """Fetch data for all sensors."""
@@ -173,6 +185,8 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
 
     async def _handle_alarm_notifications(self):
         """Raise notification if new alarm codes appear."""
+        if not self._enable_alarm_notifications:
+            return
         try:
             for sensor in self._device_data.get("sensors", []):
                 key = f"{sensor.get('device_id')}-{sensor.get('room_id')}-{sensor.get('zone_id')}"
@@ -180,6 +194,12 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
                 if alarm_code is None or alarm_code == 0:
                     # clear last stored to allow future notifications
                     self._last_alarm_codes.pop(key, None)
+                    continue
+
+                if alarm_code in self._filtered_alarm_codes:
+                    _LOGGER.debug("Skipping notification for filtered alarm code: %s", alarm_code)
+                    # Still track the alarm code to avoid repeated processing on next poll
+                    self._last_alarm_codes[key] = alarm_code
                     continue
 
                 prev_code = self._last_alarm_codes.get(key)
@@ -231,6 +251,8 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
 
     async def _handle_installation_alarms(self, api):
         """Handle notifications for installation-level alarms."""
+        if not self._enable_alarm_notifications:
+            return
         installation_alarms_data = self.get_installation_alarms_data()
         alarms = installation_alarms_data.get("data", [])
         if not alarms:
@@ -249,6 +271,13 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
             if alarm_id is None:
                 continue
 
+            # Generate notification
+            code = alarm.get("code")
+
+            if code in self._filtered_alarm_codes:
+                _LOGGER.debug("Skipping notification for filtered installation alarm code: %s", code)
+                continue
+
             current_active_ids.add(alarm_id)
 
             if alarm_id in self._notified_installation_alarm_ids:
@@ -257,8 +286,6 @@ class CSNetHomeCoordinator(DataUpdateCoordinator):
             # New active alarm found
             self._notified_installation_alarm_ids.add(alarm_id)
 
-            # Generate notification
-            code = alarm.get("code")
             unit_id = alarm.get("unitId")
 
             description = api.translate_alarm(code) if code != -1 else "System/Communication Error"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,7 +7,16 @@ from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.csnet_home.const import CONF_FAN_COIL_MODEL, CONF_LANGUAGE, CONF_MAX_TEMP_OVERRIDE, DOMAIN
+from custom_components.csnet_home.const import (
+    CONF_ENABLE_ALARM_NOTIFICATIONS,
+    CONF_FAN_COIL_MODEL,
+    CONF_FILTERED_ALARM_CODES,
+    CONF_LANGUAGE,
+    CONF_MAX_TEMP_OVERRIDE,
+    DEFAULT_ENABLE_ALARM_NOTIFICATIONS,
+    DEFAULT_FILTERED_ALARM_CODES,
+    DOMAIN,
+)
 
 # Define test constants
 TEST_USERNAME = "test_user"
@@ -16,6 +25,8 @@ TEST_SCAN_INTERVAL = 60
 TEST_LANGUAGE = "en"
 TEST_MAX_TEMP = 35
 TEST_FAN_COIL_MODEL = "standard"
+TEST_ENABLE_ALARM_NOTIFICATIONS = True
+TEST_FILTERED_ALARM_CODES = "-1"
 
 TEST_CONFIG = {
     CONF_USERNAME: TEST_USERNAME,
@@ -24,6 +35,8 @@ TEST_CONFIG = {
     CONF_LANGUAGE: TEST_LANGUAGE,
     CONF_MAX_TEMP_OVERRIDE: TEST_MAX_TEMP,
     CONF_FAN_COIL_MODEL: TEST_FAN_COIL_MODEL,
+    CONF_ENABLE_ALARM_NOTIFICATIONS: TEST_ENABLE_ALARM_NOTIFICATIONS,
+    CONF_FILTERED_ALARM_CODES: TEST_FILTERED_ALARM_CODES,
 }
 
 
@@ -262,3 +275,85 @@ async def test_validate_credentials_connection_error(hass: HomeAssistant):
         # Should show form with connection error
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_config_flow_saves_alarm_notification_options(hass: HomeAssistant):
+    """Test that config flow saves alarm notification options."""
+    with patch(
+        "custom_components.csnet_home.api.CSNetHomeAPI.async_validate_credentials",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # Config with custom alarm options
+        custom_config = TEST_CONFIG.copy()
+        custom_config[CONF_ENABLE_ALARM_NOTIFICATIONS] = False
+        custom_config[CONF_FILTERED_ALARM_CODES] = "-1,-2,-3"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=custom_config)
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_ENABLE_ALARM_NOTIFICATIONS] is False
+        assert result["data"][CONF_FILTERED_ALARM_CODES] == "-1,-2,-3"
+
+
+async def test_config_flow_default_alarm_notification_options(hass: HomeAssistant):
+    """Test that config flow uses default alarm notification options."""
+    with patch(
+        "custom_components.csnet_home.api.CSNetHomeAPI.async_validate_credentials",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # Config without custom alarm options
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=TEST_CONFIG)
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_ENABLE_ALARM_NOTIFICATIONS] is DEFAULT_ENABLE_ALARM_NOTIFICATIONS
+        assert result["data"][CONF_FILTERED_ALARM_CODES] == DEFAULT_FILTERED_ALARM_CODES
+
+
+async def test_reconfigure_flow_updates_alarm_notification_options(hass: HomeAssistant):
+    """Test that reconfigure flow updates alarm notification options."""
+    # Create an existing config entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=TEST_CONFIG,
+        entry_id="test_entry_id",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.csnet_home.api.CSNetHomeAPI.async_validate_credentials",
+        return_value=True,
+    ):
+        # Start reconfigure flow
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+        # Update alarm notification options
+        new_config = TEST_CONFIG.copy()
+        new_config[CONF_ENABLE_ALARM_NOTIFICATIONS] = False
+        new_config[CONF_FILTERED_ALARM_CODES] = "-5,-10"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=new_config)
+
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+
+        # Verify the entry was updated
+        updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
+        assert updated_entry.data[CONF_ENABLE_ALARM_NOTIFICATIONS] is False
+        assert updated_entry.data[CONF_FILTERED_ALARM_CODES] == "-5,-10"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -384,3 +384,219 @@ async def test_coordinator_get_sensor_data_by_id(hass: HomeAssistant):
     assert coordinator.get_sensor_data_by_id(1, 10, 1) == sensor_1
     assert coordinator.get_sensor_data_by_id(2, 20, 2) == sensor_2
     assert coordinator.get_sensor_data_by_id(3, 30, 3) is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_filtered_alarm_code_skipped(hass: HomeAssistant):
+    """Test that filtered alarm codes (default: -1) are skipped from notifications."""
+    mock_api = MagicMock()
+    mock_api.load_translations = AsyncMock()
+    mock_api.async_get_elements_data = AsyncMock(
+        return_value={
+            "common_data": {"name": "Test Home"},
+            "sensors": [
+                {
+                    "device_id": 123,
+                    "room_id": 456,
+                    "zone_id": 789,
+                    "device_name": "Test Device",
+                    "room_name": "Test Room",
+                    "alarm_code": -1,
+                    "alarm_message": "System/Communication Error",
+                    "unit_type": "standard",
+                }
+            ],
+        }
+    )
+    mock_api.async_get_installation_devices_data = AsyncMock(return_value=None)
+    mock_api.async_get_installation_alarms = AsyncMock(return_value=None)
+
+    hass.data["csnet_home"] = {"test": {"api": mock_api}}
+
+    # Default: filtered_alarm_codes = "-1" which should filter out alarm_code -1
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test")
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock) as mock_async_call:
+        await coordinator._async_update_data()
+
+        # Verify alarm code was stored (tracking still happens)
+        assert coordinator._last_alarm_codes["123-456-789"] == -1
+
+        # Verify NO notification was sent (filtered)
+        mock_async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_filtered_alarm_codes_custom(hass: HomeAssistant):
+    """Test that custom filtered alarm codes are respected."""
+    mock_api = MagicMock()
+    mock_api.load_translations = AsyncMock()
+    mock_api.async_get_elements_data = AsyncMock(
+        return_value={
+            "common_data": {"name": "Test Home"},
+            "sensors": [
+                {
+                    "device_id": 123,
+                    "room_id": 456,
+                    "zone_id": 789,
+                    "device_name": "Test Device",
+                    "room_name": "Test Room",
+                    "alarm_code": -5,
+                    "alarm_message": "Communication Error",
+                    "unit_type": "standard",
+                }
+            ],
+        }
+    )
+    mock_api.async_get_installation_devices_data = AsyncMock(return_value=None)
+    mock_api.async_get_installation_alarms = AsyncMock(return_value=None)
+
+    hass.data["csnet_home"] = {"test": {"api": mock_api}}
+
+    # Custom filtered codes: -5 should be filtered
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test", filtered_alarm_codes="-5,-10")
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock) as mock_async_call:
+        await coordinator._async_update_data()
+
+        # Verify NO notification was sent (filtered)
+        mock_async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_disabled_alarm_notifications(hass: HomeAssistant):
+    """Test that disabled alarm notifications suppress all notifications."""
+    mock_api = MagicMock()
+    mock_api.load_translations = AsyncMock()
+    mock_api.async_get_elements_data = AsyncMock(
+        return_value={
+            "common_data": {"name": "Test Home"},
+            "sensors": [
+                {
+                    "device_id": 123,
+                    "room_id": 456,
+                    "zone_id": 789,
+                    "device_name": "Test Device",
+                    "room_name": "Test Room",
+                    "alarm_code": 42,
+                    "alarm_code_formatted": "E42",
+                    "alarm_message": "Real Alarm",
+                    "unit_type": "standard",
+                }
+            ],
+        }
+    )
+    mock_api.async_get_installation_devices_data = AsyncMock(return_value=None)
+    mock_api.async_get_installation_alarms = AsyncMock(return_value=None)
+
+    hass.data["csnet_home"] = {"test": {"api": mock_api}}
+
+    # Disable all alarm notifications
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test", enable_alarm_notifications=False)
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock) as mock_async_call:
+        await coordinator._async_update_data()
+
+        # Verify NO notification was sent (disabled)
+        mock_async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_parse_filtered_alarm_codes(hass: HomeAssistant):
+    """Test parsing of comma-separated alarm codes."""
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test", filtered_alarm_codes="-1,-2,10,20")
+
+    assert coordinator._filtered_alarm_codes == {-1, -2, 10, 20}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_parse_filtered_alarm_codes_empty(hass: HomeAssistant):
+    """Test parsing empty alarm codes string."""
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test", filtered_alarm_codes="")
+
+    assert coordinator._filtered_alarm_codes == set()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_parse_filtered_alarm_codes_invalid(hass: HomeAssistant):
+    """Test parsing invalid alarm codes string."""
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test", filtered_alarm_codes="abc,def")
+
+    assert coordinator._filtered_alarm_codes == set()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_installation_alarm_filtered(hass: HomeAssistant):
+    """Test that installation alarms with filtered codes are suppressed."""
+    mock_api = MagicMock()
+    mock_api.load_translations = AsyncMock()
+    mock_api.async_get_elements_data = AsyncMock(
+        return_value={
+            "common_data": {"name": "Test Home"},
+            "sensors": [],
+        }
+    )
+    mock_api.async_get_installation_devices_data = AsyncMock(return_value=None)
+    mock_api.async_get_installation_alarms = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": 123,
+                    "code": -1,
+                    "unitId": 456,
+                    "recoveredAtString": "1980-01-01 00:00:00",
+                }
+            ]
+        }
+    )
+
+    hass.data["csnet_home"] = {"test": {"api": mock_api}}
+
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test")
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock) as mock_async_call:
+        await coordinator._async_update_data()
+
+        # Verify NO notification was sent (filtered)
+        mock_async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_installation_alarm_not_filtered(hass: HomeAssistant):
+    """Test that installation alarms not in filter list are sent."""
+    mock_api = MagicMock()
+    mock_api.load_translations = AsyncMock()
+    mock_api.async_get_elements_data = AsyncMock(
+        return_value={
+            "common_data": {"name": "Test Home"},
+            "sensors": [],
+        }
+    )
+    mock_api.async_get_installation_devices_data = AsyncMock(return_value=None)
+    mock_api.async_get_installation_alarms = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": 123,
+                    "code": 42,
+                    "unitId": 456,
+                    "recoveredAtString": "1980-01-01 00:00:00",
+                }
+            ]
+        }
+    )
+    mock_api.translate_alarm = MagicMock(return_value="Test Alarm")
+
+    hass.data["csnet_home"] = {"test": {"api": mock_api}}
+
+    coordinator = CSNetHomeCoordinator(hass=hass, update_interval=30, entry_id="test")
+
+    with patch("homeassistant.core.ServiceRegistry.async_call", new_callable=AsyncMock) as mock_async_call:
+        await coordinator._async_update_data()
+
+        # Verify notification WAS sent (not filtered)
+        mock_async_call.assert_called_once()
+        args, kwargs = mock_async_call.call_args
+        assert args[0] == "persistent_notification"
+        assert args[1] == "create"
+        assert "123" in args[2]["notification_id"]


### PR DESCRIPTION
## Summary

Add the ability to filter or disable alarm notifications via configuration options (Feature Request #193).

### Problem

The integration creates persistent notifications for every alarm, including transient communication errors (Code: -1) that are not real hardware faults. These frequent notifications can be annoying and don't indicate actual issues.

### Solution

Added two new configuration options:

1. **`Enable Alarm Notifications`** (boolean, default: `true`)
   - When disabled, no alarm notifications will be created
   - Allows complete suppression of alarm notifications

2. **`Filtered Alarm Codes`** (string, default: `-1`)
   - Comma-separated list of alarm codes to suppress
   - Default filters out communication errors (code -1)
   - Users can customize to filter additional codes (e.g., `-1,-2,-3`)

### Changes

| File | Description |
|------|-------------|
| `const.py` | Added `CONF_ENABLE_ALARM_NOTIFICATIONS`, `CONF_FILTERED_ALARM_CODES`, and defaults |
| `config_flow.py` | Added options to user and reconfigure flows |
| `coordinator.py` | Added filter logic in `_handle_alarm_notifications()` and `_handle_installation_alarms()` |
| `__init__.py` | Pass config options to coordinator |
| `tests/test_config_flow.py` | Added tests for new config options |
| `tests/test_coordinator.py` | Added tests for alarm filtering logic |

### Usage

Users can configure these options:
- During initial integration setup (Configure dialog)
- Via the Reconfigure option in the UI

Examples:
- Disable all notifications: `Enable Alarm Notifications = false`
- Filter additional codes: `Filtered Alarm Codes = -1,-2,-3`
- Use defaults (filter -1 only): Leave options at default values

### Testing

All 34 tests pass:
- Config flow tests verify options are saved correctly
- Coordinator tests verify filtered codes are suppressed
- Coordinator tests verify disabled notifications work correctly
- Installation alarm filtering tests included