### PR TITLE
Fix cooling min temperature locked at 20°C for water circuits

### DIFF
--- a/custom_components/csnet_home/api.py
+++ b/custom_components/csnet_home/api.py
@@ -18,11 +18,15 @@ from custom_components.csnet_home.const import (
     ELEMENTS_PATH,
     HEAT_SETTINGS_PATH,
     HEATING_MAX_TEMPERATURE,
+    HEATING_MIN_TEMPERATURE,
     INSTALLATION_ALARMS_PATH,
     INSTALLATION_DEVICES_PATH,
     LANGUAGE_FILES,
     LOGIN_PATH,
+    WATER_CIRCUIT_MAX_COOL,
     WATER_CIRCUIT_MAX_HEAT,
+    WATER_CIRCUIT_MIN_COOL,
+    WATER_CIRCUIT_MIN_HEAT,
     WATER_HEATER_MAX_TEMPERATURE,
 )
 
@@ -31,13 +35,20 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class TemperatureLimitConfig:
-    """Configuration for temperature limits for a zone."""
+    """Configuration for temperature limits for a zone.
+
+    Matches JavaScript getUnitMinimumSettingComplex / getUnitMaximumSettingComplex.
+    Each zone has separate defaults for heating vs cooling min/max.
+    """
 
     heat_min_key: str
     heat_max_key: str
     cool_min_key: str
     cool_max_key: str
-    default_max: int
+    default_heat_max: int
+    default_cool_max: int
+    default_heat_min: int
+    default_cool_min: int
 
 
 TEMPERATURE_LIMIT_CONFIGS = {
@@ -47,6 +58,9 @@ TEMPERATURE_LIMIT_CONFIGS = {
         "coolAirMinC1",
         "coolAirMaxC1",
         HEATING_MAX_TEMPERATURE,
+        HEATING_MAX_TEMPERATURE,
+        HEATING_MIN_TEMPERATURE,
+        HEATING_MIN_TEMPERATURE,
     ),
     2: TemperatureLimitConfig(
         "heatAirMinC2",
@@ -54,9 +68,30 @@ TEMPERATURE_LIMIT_CONFIGS = {
         "coolAirMinC2",
         "coolAirMaxC2",
         HEATING_MAX_TEMPERATURE,
+        HEATING_MAX_TEMPERATURE,
+        HEATING_MIN_TEMPERATURE,
+        HEATING_MIN_TEMPERATURE,
     ),
-    5: TemperatureLimitConfig("heatMinC1", "heatMaxC1", "coolMinC1", "coolMaxC1", WATER_CIRCUIT_MAX_HEAT),
-    6: TemperatureLimitConfig("heatMinC2", "heatMaxC2", "coolMinC2", "coolMaxC2", WATER_CIRCUIT_MAX_HEAT),
+    5: TemperatureLimitConfig(
+        "heatMinC1",
+        "heatMaxC1",
+        "coolMinC1",
+        "coolMaxC1",
+        WATER_CIRCUIT_MAX_HEAT,
+        WATER_CIRCUIT_MAX_COOL,
+        WATER_CIRCUIT_MIN_HEAT,
+        WATER_CIRCUIT_MIN_COOL,
+    ),
+    6: TemperatureLimitConfig(
+        "heatMinC2",
+        "heatMaxC2",
+        "coolMinC2",
+        "coolMaxC2",
+        WATER_CIRCUIT_MAX_HEAT,
+        WATER_CIRCUIT_MAX_COOL,
+        WATER_CIRCUIT_MIN_HEAT,
+        WATER_CIRCUIT_MIN_COOL,
+    ),
 }
 
 TO_REDACT = {
@@ -684,12 +719,13 @@ class CSNetHomeAPI:
         if is_heating:
             raw_min = heating_status.get(config.heat_min_key)
             raw_max = heating_status.get(config.heat_max_key)
+            min_temp = self._validate_value(raw_min, config.default_heat_min)
+            max_temp = self._validate_value(raw_max, config.default_heat_max)
         else:
             raw_min = heating_status.get(config.cool_min_key)
             raw_max = heating_status.get(config.cool_max_key)
-
-        max_temp = self._validate_value(raw_max, config.default_max)
-        min_temp = raw_min
+            min_temp = self._validate_value(raw_min, config.default_cool_min)
+            max_temp = self._validate_value(raw_max, config.default_cool_max)
 
         return (min_temp, max_temp)
 

--- a/custom_components/csnet_home/climate.py
+++ b/custom_components/csnet_home/climate.py
@@ -24,7 +24,9 @@ from .const import (
     OPERATION_STATUS_MAP,
     OTC_COOLING_TYPE_NAMES,
     OTC_HEATING_TYPE_NAMES,
+    WATER_CIRCUIT_MAX_COOL,
     WATER_CIRCUIT_MAX_HEAT,
+    WATER_CIRCUIT_MIN_COOL,
     WATER_CIRCUIT_MIN_HEAT,
 )
 from .helpers import extract_heating_status
@@ -572,8 +574,19 @@ class CSNetHomeClimate(CoordinatorEntity, ClimateEntity):
             return self._cached_limits
 
         zone_id = self._sensor_data.get("zone_id")
-        default_min = WATER_CIRCUIT_MIN_HEAT if zone_id in [5, 6] else HEATING_MIN_TEMPERATURE
-        default_max = WATER_CIRCUIT_MAX_HEAT if zone_id in [5, 6] else HEATING_MAX_TEMPERATURE
+        mode = self._sensor_data.get("mode", 1)
+        is_cooling = mode == 0
+
+        if zone_id in [5, 6]:
+            if is_cooling:
+                default_min = WATER_CIRCUIT_MIN_COOL
+                default_max = WATER_CIRCUIT_MAX_COOL
+            else:
+                default_min = WATER_CIRCUIT_MIN_HEAT
+                default_max = WATER_CIRCUIT_MAX_HEAT
+        else:
+            default_min = HEATING_MIN_TEMPERATURE
+            default_max = HEATING_MAX_TEMPERATURE
 
         min_limit = default_min
         max_limit = default_max
@@ -583,7 +596,6 @@ class CSNetHomeClimate(CoordinatorEntity, ClimateEntity):
 
         if installation_devices_data:
             cloud_api = self.hass.data[DOMAIN][self.entry.entry_id]["api"]
-            mode = self._sensor_data.get("mode", 1)
             raw_min, raw_max = cloud_api.get_temperature_limits(zone_id, mode, installation_devices_data)
 
             normalized_min = self._normalize_temperature_limit(raw_min)

--- a/custom_components/csnet_home/const.py
+++ b/custom_components/csnet_home/const.py
@@ -36,11 +36,13 @@ SWIMMING_POOL_MIN_TEMPERATURE = 24
 
 # Air circuit (RTU) temperature limits - for zones 1, 2 (C1_AIR, C2_AIR)
 HEATING_MAX_TEMPERATURE = 35  # RTU_MAX from JavaScript
-HEATING_MIN_TEMPERATURE = 8
+HEATING_MIN_TEMPERATURE = 11  # RTU_MIN from JavaScript
 
 # Water circuit temperature limits - for zones 5, 6 (C1_WATER, C2_WATER)
 WATER_CIRCUIT_MAX_HEAT = 80  # C1_MAX_HEAT / C2_MAX_HEAT from JavaScript
-WATER_CIRCUIT_MIN_HEAT = 20
+WATER_CIRCUIT_MIN_HEAT = 20  # C1_MIN_HEAT / C2_MIN_HEAT from JavaScript
+WATER_CIRCUIT_MAX_COOL = 22  # C1_MAX_COOL / C2_MAX_COOL from JavaScript
+WATER_CIRCUIT_MIN_COOL = 5  # C1_MIN_COOL / C2_MIN_COOL from JavaScript
 
 # Fan Speed Control (for fan coil systems)
 FAN_SPEED_OFF = "0"

--- a/custom_components/csnet_home/number.py
+++ b/custom_components/csnet_home/number.py
@@ -9,7 +9,15 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, OTC_COOLING_TYPE_FIX, OTC_HEATING_TYPE_FIX, WATER_CIRCUIT_MAX_HEAT, WATER_CIRCUIT_MIN_HEAT
+from .const import (
+    DOMAIN,
+    OTC_COOLING_TYPE_FIX,
+    OTC_HEATING_TYPE_FIX,
+    WATER_CIRCUIT_MAX_COOL,
+    WATER_CIRCUIT_MAX_HEAT,
+    WATER_CIRCUIT_MIN_COOL,
+    WATER_CIRCUIT_MIN_HEAT,
+)
 from .coordinator import CSNetHomeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,8 +158,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class CSNetHomeFixedWaterTemperatureNumber(CoordinatorEntity, NumberEntity):
     """Representation of a fixed water temperature number entity."""
 
-    _attr_native_min_value = WATER_CIRCUIT_MIN_HEAT
-    _attr_native_max_value = WATER_CIRCUIT_MAX_HEAT
     _attr_native_step = 1.0
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_mode = NumberMode.AUTO
@@ -173,6 +179,14 @@ class CSNetHomeFixedWaterTemperatureNumber(CoordinatorEntity, NumberEntity):
         self._circuit = circuit
         self._mode = mode  # 0 = cool, 1 = heat
         self.entry = entry
+
+        # Set temperature limits based on mode
+        if mode == 1:  # Heating
+            self._attr_native_min_value = WATER_CIRCUIT_MIN_HEAT
+            self._attr_native_max_value = WATER_CIRCUIT_MAX_HEAT
+        else:  # Cooling
+            self._attr_native_min_value = WATER_CIRCUIT_MIN_COOL
+            self._attr_native_max_value = WATER_CIRCUIT_MAX_COOL
 
         # Determine name based on mode
         mode_name = "Heating" if mode == 1 else "Cooling"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
 [tool:pytest]
 testpaths = tests
 norecursedirs = .git
+pythonpath = .
 log_level=INFO
 addopts =
     --strict-markers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,18 @@
 """Pytest configuration and fixtures for CSNet Home tests."""
 
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
-from tests.fixtures.conftest_fixtures import load_fixture as _load_fixture
+# Add project root to sys.path so custom_components can be imported
+project_root = Path(__file__).parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from tests.fixtures.conftest_fixtures import load_fixture as _load_fixture  # noqa: E402  # noqa: E402
 
 # Mock external dependencies if not available
 try:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -116,6 +116,12 @@ def mock_deps():
         # Import or reload the module under test
         # Reload to ensure it uses our patched dependencies
         import importlib
+        from pathlib import Path
+
+        # Add project root to sys.path if not already there
+        project_root = str(Path(__file__).parent.parent)
+        if project_root not in sys.path:
+            sys.path.insert(0, project_root)
 
         import custom_components.csnet_home.const
         import custom_components.csnet_home.number
@@ -355,6 +361,45 @@ def test_number_entity_properties(mock_deps, mock_hass_instance, mock_entry, moc
     assert info["manufacturer"] == "Hitachi"
     assert info["name"] == "Controller-Living Room"
     assert info["sw_version"] == "1.0"
+
+
+def test_number_entity_cooling_mode_properties(mock_deps, mock_hass_instance, mock_entry, mock_coordinator):
+    """Test properties of the number entity in cooling mode."""
+    sensor_data = {
+        "zone_id": 1,
+        "device_id": 123,
+        "room_name": "Living Room",
+        "device_name": "Controller",
+        "parent_id": 100,
+    }
+    common_data = {
+        "name": "House",
+        "firmware": "1.0",
+        "device_status": {123: {"firmware": "2.0"}},
+    }
+
+    entity = mock_deps.CSNetHomeFixedWaterTemperatureNumber(
+        mock_coordinator,
+        sensor_data,
+        common_data,
+        circuit=1,
+        mode=0,  # Cooling
+        entry=mock_entry,
+    )
+    entity.hass = mock_hass_instance
+
+    # Verify cooling mode uses correct limits
+    assert entity.native_min_value == mock_deps.WATER_CIRCUIT_MIN_COOL
+    assert entity.native_max_value == mock_deps.WATER_CIRCUIT_MAX_COOL
+    assert entity.native_step == 1.0
+    from homeassistant.const import UnitOfTemperature
+
+    assert entity.native_unit_of_measurement == UnitOfTemperature.CELSIUS
+    from homeassistant.components.number import NumberMode
+
+    assert entity.mode == NumberMode.AUTO
+    assert entity.name == "Living Room Fixed Water Temperature Cooling C1"
+    assert entity.unique_id == f"{mock_deps.DOMAIN}-fixed-water-temp-c1-cooling-123"
 
 
 def test_number_native_value(mock_deps, mock_hass_instance, mock_entry, mock_coordinator):


### PR DESCRIPTION
## Description

Fixes #197 - Cooling mode could not set temperature below 20°C on water circuit zones (5, 6) because the integration incorrectly used heating defaults `WATER_CIRCUIT_MIN_HEAT=20` for cooling mode.

## Root Cause

After comparing with the official CSNet Manager JavaScript (`utils.js`), several issues were found:

### 1. Missing cooling-specific constants for water circuits
The JS code defines separate min/max defaults for heating vs cooling on water circuits:
| Constants | JS (correct) | Python (before fix) |
|-----------|-------------|---------------------|
| `coolMinC1` / `coolMinC2` fallback | `C1_MIN_COOL=5` | `WATER_CIRCUIT_MIN_HEAT=20` ❌ |
| `coolMaxC1` / `coolMaxC2` fallback | `C1_MAX_COOL=22` | `WATER_CIRCUIT_MAX_HEAT=80` ❌ |

### 2. `min_temp` not validated with `_validate_value()`
The `get_temperature_limits()` method only validated `max_temp` with `_validate_value()`. The `min_temp` was used raw, meaning null/0/-1 sentinel values were passed downstream. The JS `getUnitMinimumSettingComplex()` wraps both min and max in `validateValue()`.

### 3. `HEATING_MIN_TEMPERATURE` wrong (8 vs 11)
JS uses `RTU_MIN=11` while Python had `HEATING_MIN_TEMPERATURE=8`.

## Changes

### `custom_components/csnet_home/const.py`
- Added `WATER_CIRCUIT_MIN_COOL=5` and `WATER_CIRCUIT_MAX_COOL=22`
- Fixed `HEATING_MIN_TEMPERATURE=11` (was 8)

### `custom_components/csnet_home/api.py`
- Extended `TemperatureLimitConfig` with mode-specific defaults: `default_heat_max`, `default_cool_max`, `default_heat_min`, `default_cool_min`
- Updated `TEMPERATURE_LIMIT_CONFIGS` with proper cooling defaults for all zones
- Fixed `get_temperature_limits()` to validate both `min_temp` and `max_temp` with `_validate_value()` using mode-appropriate defaults

### `custom_components/csnet_home/climate.py`
- Updated `_calculate_temperature_limits()` to select mode-appropriate defaults for water circuits (cooling: 5-22°C, heating: 20-80°C)

## Testing
- All 18 temperature limit tests pass
- All 67 climate tests pass
- All coordinator and water heater tests pass

Closes #197